### PR TITLE
Log configuration update failures

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -131,9 +131,13 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             Files.copy(configFile.toPath(), copy.toPath());
             ConfigUpdater.update(this, "config.yml", configFile, Arrays.asList("LifePartsPerKill", "MaxHealthIncreasePerKill"));
             configFile = new File(this.getDataFolder(), "config.yml");
+        } catch (IOException e) {
+            getLogger().log(Level.SEVERE, "Failed to update config.yml", e);
+        }
 
+        try {
             //messages.yml
-            copy = new File(this.getDataFolder() + "/old/", "messages.old.yml");
+            File copy = new File(this.getDataFolder() + "/old/", "messages.old.yml");
             if (copy.exists()) {
                 //noinspection ResultOfMethodCallIgnored
                 copy.delete();
@@ -142,7 +146,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             ConfigUpdater.update(this, "messages.yml", messagesFile, Collections.emptyList());
             messagesFile = new File(this.getDataFolder(), "messages.yml");
         } catch (IOException e) {
-            //ignore
+            getLogger().log(Level.SEVERE, "Failed to update messages.yml", e);
         }
 
         //initialize config and messages


### PR DESCRIPTION
## Summary
- log failures when updating `config.yml` and `messages.yml`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b0edb588327a10b2799796822a6