### PR TITLE
Handle empty SQL queries during database setup

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -183,8 +183,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
         String[] queries = setup.split(";");
         for (String query : queries) {
+            query = query.trim();
             if (query.isEmpty()) {
-                return;
+                continue;
             }
             try (Connection conn = this.getConfigurations().getDataConfiguration().getDatabase().getDataSource().getConnection();
                  PreparedStatement stmt = conn.prepareStatement(query)) {


### PR DESCRIPTION
## Summary
- ensure database setup skips empty SQL queries instead of returning
- trim queries and continue to next when blank

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b0e5aa08327bf0a24ea2dee39c9