### PR TITLE
Close database on plugin shutdown

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -86,6 +86,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             }
         }
 
+        if (this.getConfigurations() != null && this.getConfigurations().getDataConfiguration().getDatabase() != null) {
+            this.getConfigurations().getDataConfiguration().getDatabase().close();
+        }
+
         super.onDisable();
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/domain/Database.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/Database.java
@@ -90,4 +90,10 @@ public class Database {
         }
         return this.dataSource;
     }
+
+    public void close() {
+        if (this.dataSource != null) {
+            this.dataSource.close();
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add close() method to Database to release data source resources safely
- ensure AugmentedHardcore.onDisable() closes configured database when shutting down

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b0ed11c8327b93594f6d6fe6140