### PR TITLE
refactor: inject plugin into PlayerData

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -56,6 +56,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
             while (resultSet.next()) {
                 if (playerData == null) {
                     playerData = new PlayerData(
+                            this.plugin,
                             player,
                             resultSet.getString("last_known_ip"),
                             resultSet.getTimestamp("last_death") == null ? LocalDateTime.now() : resultSet.getTimestamp("last_death").toLocalDateTime(),

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -47,12 +47,12 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.getConfig(player), player));
+        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player));
     }
 
     @Override
     public PlayerData getByPlayerSync(OfflinePlayer player) {
-        return PlayerData.deserialize(this.getConfig(player), player);
+        return PlayerData.deserialize(this.plugin, this.getConfig(player), player);
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -68,7 +68,7 @@ public class PlayerRepository {
 
     private PlayerData getFromDataAndCache(OfflinePlayer player, PlayerData playerData) {
         if (playerData == null) {
-            playerData = new PlayerData(player);
+            playerData = new PlayerData(this.plugin, player);
             if (player.hasPlayedBefore())
                 this.mapper.insertPlayerDataAsync(playerData);
         }


### PR DESCRIPTION
## Summary
- accept plugin reference in PlayerData and use instead of JavaPlugin.getPlugin
- pass plugin reference when constructing PlayerData instances

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b0f96f08327a5716bff8c7b0817