### PR TITLE
Add unit tests for core data components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# AugmentedHardcore
 
+This repository contains the AugmentedHardcore plugin. Unit tests are located in `src/test/java` and can be executed with Maven.
+
+## Running Tests
+
+```bash
+mvn test
+```
+
+The tests cover core components such as the `Database` and `PlayerData` classes. They rely on Mockito to mock Bukkit APIs where necessary.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     </repositories>
     <build>
         <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
         <defaultGoal>clean package</defaultGoal>
         <resources>
             <resource>
@@ -55,7 +56,15 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <excludes>
+                        <exclude>test/**</exclude>
+                    </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -115,6 +124,30 @@
             <groupId>com.tchristofferson</groupId>
             <artifactId>ConfigUpdater</artifactId>
             <version>2.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>5.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>5.2.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/backtobedrock/augmentedhardcore/domain/DatabaseTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/domain/DatabaseTest.java
@@ -1,0 +1,47 @@
+package com.backtobedrock.augmentedhardcore.domain;
+
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
+import com.zaxxer.hikari.HikariDataSource;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class DatabaseTest {
+
+    @Test
+    void testGetDataSourceConfiguration() {
+        Database db = new Database("localhost", "3306", "testdb", "user", "pass");
+        HikariDataSource ds = db.getDataSource();
+        assertEquals("jdbc:mysql://localhost:3306/testdb", ds.getJdbcUrl());
+        assertEquals("user", ds.getUsername());
+        assertEquals("pass", ds.getPassword());
+        assertEquals("true", ds.getDataSourceProperties().getProperty("autoReconnect"));
+    }
+
+    @Test
+    void testDeserialize() {
+        ConfigurationSection section = mock(ConfigurationSection.class);
+        when(section.getString("Hostname")).thenReturn("localhost");
+        when(section.getString("Port", "3306")).thenReturn("3306");
+        when(section.getString("Database")).thenReturn("db");
+        when(section.getString("Username")).thenReturn("user");
+        when(section.getString("Password")).thenReturn("pwd");
+
+        AugmentedHardcore plugin = mock(AugmentedHardcore.class);
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        try (MockedStatic<JavaPlugin> mocked = Mockito.mockStatic(JavaPlugin.class)) {
+            mocked.when(() -> JavaPlugin.getPlugin(AugmentedHardcore.class)).thenReturn(plugin);
+            Database db = Database.deserialize(section);
+            assertNotNull(db);
+            assertEquals("localhost", db.getHostname());
+            assertEquals("db", db.getDatabaseName());
+        }
+    }
+}

--- a/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
@@ -1,0 +1,67 @@
+package com.backtobedrock.augmentedhardcore.domain.data;
+
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
+import com.backtobedrock.augmentedhardcore.configs.Configurations;
+import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationLivesAndLifeParts;
+import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationMaxHealth;
+import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationRevive;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PlayerDataTest {
+
+    @Test
+    void testSerializeIncludesCoreFields() {
+        AugmentedHardcore plugin = mock(AugmentedHardcore.class);
+        Configurations configs = mock(Configurations.class);
+        ConfigurationLivesAndLifeParts livesConfig = mock(ConfigurationLivesAndLifeParts.class);
+        ConfigurationMaxHealth maxHealthConfig = mock(ConfigurationMaxHealth.class);
+        ConfigurationRevive reviveConfig = mock(ConfigurationRevive.class);
+
+        when(plugin.getConfigurations()).thenReturn(configs);
+        when(configs.getLivesAndLifePartsConfiguration()).thenReturn(livesConfig);
+        when(livesConfig.getPlaytimePerLifePart()).thenReturn(1000);
+        when(configs.getMaxHealthConfiguration()).thenReturn(maxHealthConfig);
+        when(maxHealthConfig.getPlaytimePerHalfHeart()).thenReturn(2000);
+        when(configs.getReviveConfiguration()).thenReturn(reviveConfig);
+        when(reviveConfig.getTimeBetweenRevives()).thenReturn(5000);
+
+        OfflinePlayer offline = mock(OfflinePlayer.class);
+        when(offline.getPlayer()).thenReturn(null);
+        when(offline.getUniqueId()).thenReturn(UUID.randomUUID());
+        when(offline.getName()).thenReturn("Steve");
+
+        try (MockedStatic<JavaPlugin> mocked = Mockito.mockStatic(JavaPlugin.class)) {
+            mocked.when(() -> JavaPlugin.getPlugin(AugmentedHardcore.class)).thenReturn(plugin);
+
+            PlayerData data = new PlayerData(
+                    offline,
+                    "127.0.0.1",
+                    LocalDateTime.of(2023,1,1,0,0),
+                    3,
+                    5,
+                    true,
+                    1200,
+                    400,
+                    800,
+                    new TreeMap<>());
+
+            Map<String, Object> serialized = data.serialize();
+            assertEquals(3, serialized.get("Lives"));
+            assertEquals(5, serialized.get("LifeParts"));
+            assertEquals("127.0.0.1", serialized.get("LastKnownIp"));
+            assertEquals(true, serialized.get("SpectatorBanned"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- configure Maven test setup with JUnit and Mockito
- add Database and PlayerData unit tests with mocked Bukkit APIs
- document how to run the test suite

## Testing
- `mvn test` *(fails: Could not transfer artifact maven-resources-plugin due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b34b1001ec83279b9f69d896ac669a