### PR TITLE
Use ConcurrentHashMap for player cache

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -11,10 +11,10 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class PlayerRepository {
     private final AugmentedHardcore plugin;
@@ -25,7 +25,7 @@ public class PlayerRepository {
 
     public PlayerRepository() {
         this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
-        this.playerCache = new HashMap<>();
+        this.playerCache = new ConcurrentHashMap<>();
         this.initializeMapper();
     }
 


### PR DESCRIPTION
## Summary
- Replace HashMap player cache with ConcurrentHashMap for thread-safe access

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3548515a88327b2c08da0a7d440ed