### PR TITLE
Improve error logging in repositories and mappers

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.NavigableMap;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
     private static MySQLPlayerMapper instance;
@@ -27,7 +28,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
     @Override
     public void insertPlayerDataAsync(PlayerData playerData) {
         CompletableFuture.runAsync(() -> this.updatePlayerData(playerData)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not insert PlayerData for %s.", playerData.getPlayer().getName()), ex);
             return null;
         });
     }
@@ -92,7 +93,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
             this.updatePlayerDataSync(playerData);
         } else {
             CompletableFuture.runAsync(() -> this.updatePlayerDataSync(playerData)).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, String.format("Could not update PlayerData for %s asynchronously.", playerData.getPlayer().getName()), ex);
                 return null;
             });
         }
@@ -134,7 +135,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
             preparedStatement.setLong(19, playerData.getTimeTillNextMaxHealth());
             preparedStatement.execute();
         } catch (SQLException e) {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not update PlayerData for %s.", playerData.getPlayer().getName()), e);
         }
     }
 
@@ -148,10 +149,10 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
                 preparedStatement.setString(1, player.getUniqueId().toString());
                 preparedStatement.execute();
             } catch (SQLException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s.", player.getName()), e);
             }
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s asynchronously.", player.getName()), ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -35,7 +35,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
     @Override
     public void insertPlayerDataAsync(PlayerData data) {
         CompletableFuture.runAsync(() -> this.insertPlayerData(data)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not insert PlayerData for %s.", data.getPlayer().getName()), ex);
             return null;
         });
     }
@@ -73,7 +73,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
                 file.delete();
             }
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s.", player.getName()), ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class PlayerRepository {
     private final AugmentedHardcore plugin;
@@ -52,7 +53,7 @@ public class PlayerRepository {
             return this.mapper.getByPlayer(player).thenApplyAsync(playerData -> this.getFromDataAndCache(player, playerData));
         } else {
             return CompletableFuture.supplyAsync(() -> player).thenApplyAsync(this::getFromCache).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, String.format("Failed to retrieve PlayerData for %s from cache.", player.getName()), ex);
                 return null;
             });
         }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -27,7 +27,7 @@ public class ServerRepository {
         this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
         this.initializeMapper();
         this.getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban"))).exceptionally(e -> {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Could not load server data asynchronously.", e);
             return null;
         });
     }


### PR DESCRIPTION
## Summary
- Use plugin logger with SEVERE level instead of printing stack traces in PlayerRepository, MySQLPlayerMapper, YAMLPlayerMapper, and ServerRepository
- Import `java.util.logging.Level` where needed

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b35485ede48327a42817f5f3a63481