### PR TITLE
Add shared ExecutorService for async operations

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -34,6 +34,8 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class AugmentedHardcore extends JavaPlugin implements Listener {
 
@@ -53,6 +55,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     //runnables
     private UpdateChecker updateChecker;
+
+    //executor
+    private final ExecutorService executorService = Executors.newFixedThreadPool(4);
 
     @Override
     public void onEnable() {
@@ -84,6 +89,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             if (serverData != null) {
                 this.getServerRepository().updateServerData(serverData);
             }
+        }
+
+        if (!this.executorService.isShutdown()) {
+            this.executorService.shutdown();
         }
 
         if (this.getConfigurations() != null && this.getConfigurations().getDataConfiguration().getDatabase() != null) {
@@ -281,5 +290,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     public UpdateChecker getUpdateChecker() {
         return updateChecker;
+    }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -26,7 +26,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
 
     @Override
     public void insertPlayerDataAsync(PlayerData playerData) {
-        CompletableFuture.runAsync(() -> this.updatePlayerData(playerData)).exceptionally(ex -> {
+        CompletableFuture.runAsync(() -> this.updatePlayerData(playerData), this.plugin.getExecutorService()).exceptionally(ex -> {
             ex.printStackTrace();
             return null;
         });
@@ -39,7 +39,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> this.getPlayerData(player));
+        return CompletableFuture.supplyAsync(() -> this.getPlayerData(player), this.plugin.getExecutorService());
     }
 
     private PlayerData getPlayerData(OfflinePlayer player) {
@@ -91,7 +91,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
         if (this.plugin.isStopping()) {
             this.updatePlayerDataSync(playerData);
         } else {
-            CompletableFuture.runAsync(() -> this.updatePlayerDataSync(playerData)).exceptionally(ex -> {
+            CompletableFuture.runAsync(() -> this.updatePlayerDataSync(playerData), this.plugin.getExecutorService()).exceptionally(ex -> {
                 ex.printStackTrace();
                 return null;
             });
@@ -150,7 +150,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
             } catch (SQLException e) {
                 e.printStackTrace();
             }
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutorService()).exceptionally(ex -> {
             ex.printStackTrace();
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -34,7 +34,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public void insertPlayerDataAsync(PlayerData data) {
-        CompletableFuture.runAsync(() -> this.insertPlayerData(data)).exceptionally(ex -> {
+        CompletableFuture.runAsync(() -> this.insertPlayerData(data), this.plugin.getExecutorService()).exceptionally(ex -> {
             ex.printStackTrace();
             return null;
         });
@@ -47,7 +47,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player));
+        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player), this.plugin.getExecutorService());
     }
 
     @Override
@@ -72,7 +72,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutorService()).exceptionally(ex -> {
             ex.printStackTrace();
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -49,9 +49,11 @@ public class PlayerRepository {
 
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
         if (!this.playerCache.containsKey(player.getUniqueId())) {
-            return this.mapper.getByPlayer(player).thenApplyAsync(playerData -> this.getFromDataAndCache(player, playerData));
+            return this.mapper.getByPlayer(player)
+                    .thenApplyAsync(playerData -> this.getFromDataAndCache(player, playerData), this.plugin.getExecutorService());
         } else {
-            return CompletableFuture.supplyAsync(() -> player).thenApplyAsync(this::getFromCache).exceptionally(ex -> {
+            return CompletableFuture.supplyAsync(() -> player, this.plugin.getExecutorService())
+                    .thenApplyAsync(this::getFromCache, this.plugin.getExecutorService()).exceptionally(ex -> {
                 ex.printStackTrace();
                 return null;
             });

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -26,10 +26,15 @@ public class ServerRepository {
     public ServerRepository() {
         this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
         this.initializeMapper();
-        this.getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban"))).exceptionally(e -> {
-            e.printStackTrace();
-            return null;
-        });
+        this.getServerData(this.plugin.getServer())
+                .thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO,
+                        String.format("Loaded %d ongoing death %s.",
+                                serverData.getTotalOngoingBans(),
+                                serverData.getTotalOngoingBans() != 1 ? "bans" : "ban")),
+                        this.plugin.getExecutorService()).exceptionally(e -> {
+                    e.printStackTrace();
+                    return null;
+                });
     }
 
     private void initializeMapper() {
@@ -43,9 +48,10 @@ public class ServerRepository {
 
     public CompletableFuture<ServerData> getServerData(Server server) {
         if (this.serverData == null) {
-            return this.mapper.getServerData(server).thenApplyAsync(this::getFromDataAndCache);
+            return this.mapper.getServerData(server)
+                    .thenApplyAsync(this::getFromDataAndCache, this.plugin.getExecutorService());
         } else {
-            return CompletableFuture.supplyAsync(this::getFromCache);
+            return CompletableFuture.supplyAsync(this::getFromCache, this.plugin.getExecutorService());
         }
     }
 


### PR DESCRIPTION
## Summary
- add a fixed thread pool in `AugmentedHardcore` and expose it via a getter
- use the plugin executor for async tasks in repositories and mappers
- gracefully shut down the executor during plugin disable

## Testing
- `mvn -q test` *(failed: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3548a14fc83279b1e285e8e76efc3