### PR TITLE
Refactor repositories and mappers to accept plugin instance

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -165,12 +165,12 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
         //initialize repositories
         if (this.playerRepository == null) {
-            this.playerRepository = new PlayerRepository();
+            this.playerRepository = new PlayerRepository(this);
         } else {
             this.playerRepository.onReload();
         }
         if (this.serverRepository == null) {
-            this.serverRepository = new ServerRepository();
+            this.serverRepository = new ServerRepository(this);
         }
 
         //register event listeners
@@ -206,7 +206,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
         //PATCHES
         Arrays.asList(
-                new LastDeathAdditionPatch()
+                new LastDeathAdditionPatch(this)
         ).forEach(Patch::executePatch);
 
         getLogger().info("Setup complete.");

--- a/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
@@ -2,14 +2,13 @@ package com.backtobedrock.augmentedhardcore.mappers;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Database;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public abstract class AbstractMapper {
     protected final AugmentedHardcore plugin;
     protected final Database database;
 
-    public AbstractMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public AbstractMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.database = this.plugin.getConfigurations().getDataConfiguration().getDatabase();
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/Patch.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/Patch.java
@@ -1,7 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -10,11 +9,10 @@ import java.sql.SQLException;
 import java.util.logging.Level;
 
 public abstract class Patch extends AbstractMapper {
-    private final AugmentedHardcore plugin;
     protected boolean success = false;
 
-    public Patch() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public Patch(AugmentedHardcore plugin) {
+        super(plugin);
     }
 
     protected abstract boolean hasBeenApplied();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.ban;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.Killer;
 import com.backtobedrock.augmentedhardcore.domain.Location;
@@ -17,9 +18,13 @@ import java.util.concurrent.CompletableFuture;
 public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
     private static MySQLBanMapper instance;
 
-    public static MySQLBanMapper getInstance() {
+    private MySQLBanMapper(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
+    public static MySQLBanMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
-            instance = new MySQLBanMapper();
+            instance = new MySQLBanMapper(plugin);
         }
         return instance;
     }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.player;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
@@ -17,9 +18,13 @@ import java.util.concurrent.CompletableFuture;
 public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
     private static MySQLPlayerMapper instance;
 
-    public static MySQLPlayerMapper getInstance() {
+    private MySQLPlayerMapper(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
+    public static MySQLPlayerMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
-            instance = new MySQLPlayerMapper();
+            instance = new MySQLPlayerMapper(plugin);
         }
         return instance;
     }
@@ -69,7 +74,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
                             deathBans
                     );
                 }
-                Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance().getBanFromResultSetSync(resultSet);
+                Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance(this.plugin).getBanFromResultSetSync(resultSet);
                 if (banPair != null) {
                     deathBans.put(banPair.getValue0(), banPair.getValue1());
                 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,8 +15,8 @@ import java.util.logging.Level;
 public class YAMLPlayerMapper implements IPlayerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLPlayerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLPlayerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
 
         //create userdata folder if none existent
         File udFile = new File(this.plugin.getDataFolder() + "/userdata");

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/patches/LastDeathAdditionPatch.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/patches/LastDeathAdditionPatch.java
@@ -1,8 +1,12 @@
 package com.backtobedrock.augmentedhardcore.mappers.player.patches;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.mappers.Patch;
 
 public class LastDeathAdditionPatch extends Patch {
+    public LastDeathAdditionPatch(AugmentedHardcore plugin) {
+        super(plugin);
+    }
     @Override
     protected boolean hasBeenApplied() {
         return this.containsLastDeath();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.server;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
@@ -23,9 +24,13 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     private static MySQLServerMapper instance;
 
-    public static MySQLServerMapper getInstance() {
+    private MySQLServerMapper(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
+    public static MySQLServerMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
-            instance = new MySQLServerMapper();
+            instance = new MySQLServerMapper(plugin);
         }
         return instance;
     }
@@ -61,7 +66,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                     totalDeathBans = resultSet.getInt("total_death_bans");
                     String uuidString = resultSet.getString("player_uuid");
                     if (uuidString != null && !uuidString.isEmpty()) {
-                        Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance().getBanFromResultSetSync(resultSet);
+                        Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance(this.plugin).getBanFromResultSetSync(resultSet);
                         if (banPair != null) {
                             deathBans.put(UUID.fromString(uuidString), banPair);
                         }
@@ -92,7 +97,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 e.printStackTrace();
                 return;
             }
-            data.getOngoingBans().forEach((key, value) -> MySQLBanMapper.getInstance().updateBan(this.plugin.getServer(), key, value.getBan()));
+            data.getOngoingBans().forEach((key, value) -> MySQLBanMapper.getInstance(this.plugin).updateBan(this.plugin.getServer(), key, value.getBan()));
         }).exceptionally(ex -> {
             ex.printStackTrace();
             return null;
@@ -120,6 +125,6 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     @Override
     public void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban) {
-        MySQLBanMapper.getInstance().updateBan(null, uuid, ban);
+        MySQLBanMapper.getInstance(this.plugin).updateBan(null, uuid, ban);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.io.File;
@@ -19,8 +18,8 @@ import java.util.logging.Level;
 public class YAMLServerMapper implements IServerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLServerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLServerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
     }
 
     private void insertServerData(ServerData data) {

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -9,7 +9,6 @@ import com.backtobedrock.augmentedhardcore.mappers.player.YAMLPlayerMapper;
 import com.backtobedrock.augmentedhardcore.runnables.ClearCache;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,8 +22,8 @@ public class PlayerRepository {
     private final Map<UUID, PlayerData> playerCache;
     private IPlayerMapper mapper;
 
-    public PlayerRepository() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public PlayerRepository(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.playerCache = new HashMap<>();
         this.initializeMapper();
     }
@@ -41,9 +40,9 @@ public class PlayerRepository {
 
     private void initializeMapper() {
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLPlayerMapper.getInstance();
+            this.mapper = MySQLPlayerMapper.getInstance(this.plugin);
         } else {
-            this.mapper = new YAMLPlayerMapper();
+            this.mapper = new YAMLPlayerMapper(this.plugin);
         }
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -8,7 +8,6 @@ import com.backtobedrock.augmentedhardcore.mappers.server.IServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.MySQLServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.YAMLServerMapper;
 import org.bukkit.Server;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.util.UUID;
@@ -23,8 +22,8 @@ public class ServerRepository {
     //server cache
     private ServerData serverData = null;
 
-    public ServerRepository() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public ServerRepository(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.initializeMapper();
         this.getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban"))).exceptionally(e -> {
             e.printStackTrace();
@@ -33,11 +32,11 @@ public class ServerRepository {
     }
 
     private void initializeMapper() {
-        this.mapper = new YAMLServerMapper();
+        this.mapper = new YAMLServerMapper(this.plugin);
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLServerMapper.getInstance();
+            this.mapper = MySQLServerMapper.getInstance(this.plugin);
         } else {
-            this.mapper = new YAMLServerMapper();
+            this.mapper = new YAMLServerMapper(this.plugin);
         }
     }
 


### PR DESCRIPTION
## Summary
- Inject `AugmentedHardcore` into repositories and mappers
- Remove direct `JavaPlugin.getPlugin` lookups
- Pass plugin instance when constructing repositories, mappers, and patches

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3548ac1c88327875c33b0658e09e9