### PR TITLE
Inject plugin instance and centralize async execution

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -32,6 +32,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -53,6 +55,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     //runnables
     private UpdateChecker updateChecker;
+
+    //async executor
+    private ExecutorService executor;
 
     @Override
     public void onEnable() {
@@ -86,6 +91,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             }
         }
 
+        if (this.executor != null) {
+            this.executor.shutdown();
+        }
+
         if (this.getConfigurations() != null && this.getConfigurations().getDataConfiguration().getDatabase() != null) {
             this.getConfigurations().getDataConfiguration().getDatabase().close();
         }
@@ -99,6 +108,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
     }
 
     public void initialize() {
+        if (this.executor == null || this.executor.isShutdown()) {
+            this.executor = Executors.newFixedThreadPool(Math.max(2, Runtime.getRuntime().availableProcessors()));
+        }
+
         //initialize old config directory
         File dir = new File(this.getDataFolder() + "/old");
         List<File> configs = new ArrayList<File>() {{
@@ -165,12 +178,12 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
         //initialize repositories
         if (this.playerRepository == null) {
-            this.playerRepository = new PlayerRepository();
+            this.playerRepository = new PlayerRepository(this);
         } else {
             this.playerRepository.onReload();
         }
         if (this.serverRepository == null) {
-            this.serverRepository = new ServerRepository();
+            this.serverRepository = new ServerRepository(this);
         }
 
         //register event listeners
@@ -281,5 +294,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     public UpdateChecker getUpdateChecker() {
         return updateChecker;
+    }
+
+    public ExecutorService getExecutor() {
+        return executor;
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
@@ -2,14 +2,13 @@ package com.backtobedrock.augmentedhardcore.mappers;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Database;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public abstract class AbstractMapper {
     protected final AugmentedHardcore plugin;
     protected final Database database;
 
-    public AbstractMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public AbstractMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.database = this.plugin.getConfigurations().getDataConfiguration().getDatabase();
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.ban;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.Killer;
 import com.backtobedrock.augmentedhardcore.domain.Location;
@@ -13,15 +14,20 @@ import java.net.UnknownHostException;
 import java.sql.*;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
     private static MySQLBanMapper instance;
 
-    public static MySQLBanMapper getInstance() {
+    public static synchronized MySQLBanMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
-            instance = new MySQLBanMapper();
+            instance = new MySQLBanMapper(plugin);
         }
         return instance;
+    }
+
+    private MySQLBanMapper(AugmentedHardcore plugin) {
+        super(plugin);
     }
 
     public Pair<Integer, Ban> getBanFromResultSetSync(ResultSet resultSet) {
@@ -44,7 +50,7 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 );
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Could not parse ban from result set.", e);
         }
         return null;
     }
@@ -132,10 +138,10 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 preparedStatement.setLong(46, ban.getValue1().getTimeSincePreviousDeath());
                 preparedStatement.execute();
             } catch (SQLException | UnknownHostException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not update ban.", e);
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not update ban asynchronously.", ex);
             return null;
         });
     }
@@ -151,10 +157,10 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 preparedStatement.setString(2, uuid.toString());
                 preparedStatement.execute();
             } catch (SQLException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban.", e);
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban asynchronously.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.player;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
@@ -18,16 +19,20 @@ import java.util.logging.Level;
 public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
     private static MySQLPlayerMapper instance;
 
-    public static MySQLPlayerMapper getInstance() {
+    public static synchronized MySQLPlayerMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
-            instance = new MySQLPlayerMapper();
+            instance = new MySQLPlayerMapper(plugin);
         }
         return instance;
     }
 
+    private MySQLPlayerMapper(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
     @Override
     public void insertPlayerDataAsync(PlayerData playerData) {
-        CompletableFuture.runAsync(() -> this.updatePlayerData(playerData)).exceptionally(ex -> {
+        CompletableFuture.runAsync(() -> this.updatePlayerData(playerData), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not insert PlayerData for %s.", playerData.getPlayer().getName()), ex);
             return null;
         });
@@ -40,7 +45,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> this.getPlayerData(player));
+        return CompletableFuture.supplyAsync(() -> this.getPlayerData(player), this.plugin.getExecutor());
     }
 
     private PlayerData getPlayerData(OfflinePlayer player) {
@@ -70,14 +75,14 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
                             deathBans
                     );
                 }
-                Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance().getBanFromResultSetSync(resultSet);
+                Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance(this.plugin).getBanFromResultSetSync(resultSet);
                 if (banPair != null) {
                     deathBans.put(banPair.getValue0(), banPair.getValue1());
                 }
             }
             return playerData;
         } catch (SQLException e) {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, String.format("Could not get PlayerData for %s.", player.getName()), e);
         }
         return null;
     }
@@ -92,7 +97,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
         if (this.plugin.isStopping()) {
             this.updatePlayerDataSync(playerData);
         } else {
-            CompletableFuture.runAsync(() -> this.updatePlayerDataSync(playerData)).exceptionally(ex -> {
+            CompletableFuture.runAsync(() -> this.updatePlayerDataSync(playerData), this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, String.format("Could not update PlayerData for %s asynchronously.", playerData.getPlayer().getName()), ex);
                 return null;
             });
@@ -152,7 +157,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
             } catch (SQLException e) {
                 this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s.", player.getName()), e);
             }
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s asynchronously.", player.getName()), ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,8 +15,8 @@ import java.util.logging.Level;
 public class YAMLPlayerMapper implements IPlayerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLPlayerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLPlayerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
 
         //create userdata folder if none existent
         File udFile = new File(this.plugin.getDataFolder() + "/userdata");
@@ -34,7 +33,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public void insertPlayerDataAsync(PlayerData data) {
-        CompletableFuture.runAsync(() -> this.insertPlayerData(data)).exceptionally(ex -> {
+        CompletableFuture.runAsync(() -> this.insertPlayerData(data), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not insert PlayerData for %s.", data.getPlayer().getName()), ex);
             return null;
         });
@@ -47,7 +46,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player));
+        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player), this.plugin.getExecutor());
     }
 
     @Override
@@ -72,7 +71,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s.", player.getName()), ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.io.File;
@@ -19,8 +18,8 @@ import java.util.logging.Level;
 public class YAMLServerMapper implements IServerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLServerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLServerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
     }
 
     private void insertServerData(ServerData data) {
@@ -31,8 +30,8 @@ public class YAMLServerMapper implements IServerMapper {
 
     @Override
     public void insertServerDataAsync(ServerData data) {
-        CompletableFuture.runAsync(() -> this.insertServerData(data)).exceptionally(ex -> {
-            ex.printStackTrace();
+        CompletableFuture.runAsync(() -> this.insertServerData(data), this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not insert server data.", ex);
             return null;
         });
     }
@@ -44,7 +43,7 @@ public class YAMLServerMapper implements IServerMapper {
 
     @Override
     public CompletableFuture<ServerData> getServerData(Server server) {
-        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(getConfig()));
+        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(getConfig()), this.plugin.getExecutor());
     }
 
     @Override
@@ -64,8 +63,8 @@ public class YAMLServerMapper implements IServerMapper {
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete server data file.", ex);
             return null;
         });
     }
@@ -76,8 +75,8 @@ public class YAMLServerMapper implements IServerMapper {
             FileConfiguration config = this.getConfig();
             config.set("OngoingBans." + uuid, null);
             this.saveConfig(config);
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban from server data.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -9,13 +9,12 @@ import com.backtobedrock.augmentedhardcore.mappers.player.YAMLPlayerMapper;
 import com.backtobedrock.augmentedhardcore.runnables.ClearCache;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 
 public class PlayerRepository {
     private final AugmentedHardcore plugin;
@@ -24,8 +23,8 @@ public class PlayerRepository {
     private final Map<UUID, PlayerData> playerCache;
     private IPlayerMapper mapper;
 
-    public PlayerRepository() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public PlayerRepository(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.playerCache = new ConcurrentHashMap<>();
         this.initializeMapper();
     }
@@ -42,20 +41,23 @@ public class PlayerRepository {
 
     private void initializeMapper() {
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLPlayerMapper.getInstance();
+            this.mapper = MySQLPlayerMapper.getInstance(this.plugin);
         } else {
-            this.mapper = new YAMLPlayerMapper();
+            this.mapper = new YAMLPlayerMapper(this.plugin);
         }
     }
 
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
         if (!this.playerCache.containsKey(player.getUniqueId())) {
-            return this.mapper.getByPlayer(player).thenApplyAsync(playerData -> this.getFromDataAndCache(player, playerData));
+            return this.mapper.getByPlayer(player)
+                    .thenApplyAsync(playerData -> this.getFromDataAndCache(player, playerData), this.plugin.getExecutor());
         } else {
-            return CompletableFuture.supplyAsync(() -> player).thenApplyAsync(this::getFromCache).exceptionally(ex -> {
-                this.plugin.getLogger().log(Level.SEVERE, String.format("Failed to retrieve PlayerData for %s from cache.", player.getName()), ex);
-                return null;
-            });
+            return CompletableFuture.supplyAsync(() -> player, this.plugin.getExecutor())
+                    .thenApplyAsync(this::getFromCache, this.plugin.getExecutor())
+                    .exceptionally(ex -> {
+                        this.plugin.getLogger().log(Level.SEVERE, String.format("Failed to retrieve PlayerData for %s from cache.", player.getName()), ex);
+                        return null;
+                    });
         }
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -8,7 +8,6 @@ import com.backtobedrock.augmentedhardcore.mappers.server.IServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.MySQLServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.YAMLServerMapper;
 import org.bukkit.Server;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.util.UUID;
@@ -23,29 +22,32 @@ public class ServerRepository {
     //server cache
     private ServerData serverData = null;
 
-    public ServerRepository() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public ServerRepository(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.initializeMapper();
-        this.getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban"))).exceptionally(e -> {
+        this.getServerData(this.plugin.getServer())
+                .thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban")), this.plugin.getExecutor())
+                .exceptionally(e -> {
             this.plugin.getLogger().log(Level.SEVERE, "Could not load server data asynchronously.", e);
             return null;
         });
     }
 
     private void initializeMapper() {
-        this.mapper = new YAMLServerMapper();
+        this.mapper = new YAMLServerMapper(this.plugin);
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLServerMapper.getInstance();
+            this.mapper = MySQLServerMapper.getInstance(this.plugin);
         } else {
-            this.mapper = new YAMLServerMapper();
+            this.mapper = new YAMLServerMapper(this.plugin);
         }
     }
 
     public CompletableFuture<ServerData> getServerData(Server server) {
         if (this.serverData == null) {
-            return this.mapper.getServerData(server).thenApplyAsync(this::getFromDataAndCache);
+            return this.mapper.getServerData(server)
+                    .thenApplyAsync(this::getFromDataAndCache, this.plugin.getExecutor());
         } else {
-            return CompletableFuture.supplyAsync(this::getFromCache);
+            return CompletableFuture.supplyAsync(this::getFromCache, this.plugin.getExecutor());
         }
     }
 

--- a/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
@@ -6,10 +6,7 @@ import com.backtobedrock.augmentedhardcore.domain.configurationDomain.Configurat
 import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationMaxHealth;
 import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationRevive;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.Map;
@@ -42,26 +39,23 @@ class PlayerDataTest {
         when(offline.getUniqueId()).thenReturn(UUID.randomUUID());
         when(offline.getName()).thenReturn("Steve");
 
-        try (MockedStatic<JavaPlugin> mocked = Mockito.mockStatic(JavaPlugin.class)) {
-            mocked.when(() -> JavaPlugin.getPlugin(AugmentedHardcore.class)).thenReturn(plugin);
+        PlayerData data = new PlayerData(
+                plugin,
+                offline,
+                "127.0.0.1",
+                LocalDateTime.of(2023,1,1,0,0),
+                3,
+                5,
+                true,
+                1200,
+                400,
+                800,
+                new TreeMap<>());
 
-            PlayerData data = new PlayerData(
-                    offline,
-                    "127.0.0.1",
-                    LocalDateTime.of(2023,1,1,0,0),
-                    3,
-                    5,
-                    true,
-                    1200,
-                    400,
-                    800,
-                    new TreeMap<>());
-
-            Map<String, Object> serialized = data.serialize();
-            assertEquals(3, serialized.get("Lives"));
-            assertEquals(5, serialized.get("LifeParts"));
-            assertEquals("127.0.0.1", serialized.get("LastKnownIp"));
-            assertEquals(true, serialized.get("SpectatorBanned"));
-        }
+        Map<String, Object> serialized = data.serialize();
+        assertEquals(3, serialized.get("Lives"));
+        assertEquals(5, serialized.get("LifeParts"));
+        assertEquals("127.0.0.1", serialized.get("LastKnownIp"));
+        assertEquals(true, serialized.get("SpectatorBanned"));
     }
 }


### PR DESCRIPTION
## Summary
- Replace static plugin lookups in repositories and mappers with constructor injection
- Add a dedicated ExecutorService in AugmentedHardcore and route CompletableFuture calls through it
- Update unit test to accommodate new PlayerData constructor

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving Maven plugin)*

------
https://chatgpt.com/codex/tasks/task_b_68b34a3c0228832792f85082a513429c