### PR TITLE
Refactor SQL mappers and improve error handling

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/AbstractMapper.java
@@ -2,14 +2,13 @@ package com.backtobedrock.augmentedhardcore.mappers;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Database;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public abstract class AbstractMapper {
     protected final AugmentedHardcore plugin;
     protected final Database database;
 
-    public AbstractMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public AbstractMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.database = this.plugin.getConfigurations().getDataConfiguration().getDatabase();
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.ban;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.Killer;
 import com.backtobedrock.augmentedhardcore.domain.Location;
@@ -13,15 +14,12 @@ import java.net.UnknownHostException;
 import java.sql.*;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
-    private static MySQLBanMapper instance;
 
-    public static MySQLBanMapper getInstance() {
-        if (instance == null) {
-            instance = new MySQLBanMapper();
-        }
-        return instance;
+    public MySQLBanMapper(AugmentedHardcore plugin) {
+        super(plugin);
     }
 
     public Pair<Integer, Ban> getBanFromResultSetSync(ResultSet resultSet) {
@@ -44,7 +42,7 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 );
             }
         } catch (SQLException e) {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Could not parse ban from result set.", e);
         }
         return null;
     }
@@ -132,10 +130,10 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 preparedStatement.setLong(46, ban.getValue1().getTimeSincePreviousDeath());
                 preparedStatement.execute();
             } catch (SQLException | UnknownHostException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not update ban.", e);
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not update ban asynchronously.", ex);
             return null;
         });
     }
@@ -151,10 +149,10 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 preparedStatement.setString(2, uuid.toString());
                 preparedStatement.execute();
             } catch (SQLException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban.", e);
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban asynchronously.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/YAMLPlayerMapper.java
@@ -6,7 +6,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,8 +15,8 @@ import java.util.logging.Level;
 public class YAMLPlayerMapper implements IPlayerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLPlayerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLPlayerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
 
         //create userdata folder if none existent
         File udFile = new File(this.plugin.getDataFolder() + "/userdata");
@@ -34,7 +33,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public void insertPlayerDataAsync(PlayerData data) {
-        CompletableFuture.runAsync(() -> this.insertPlayerData(data)).exceptionally(ex -> {
+        CompletableFuture.runAsync(() -> this.insertPlayerData(data), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not insert PlayerData for %s.", data.getPlayer().getName()), ex);
             return null;
         });
@@ -47,7 +46,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
 
     @Override
     public CompletableFuture<PlayerData> getByPlayer(OfflinePlayer player) {
-        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player));
+        return CompletableFuture.supplyAsync(() -> PlayerData.deserialize(this.plugin, this.getConfig(player), player), this.plugin.getExecutor());
     }
 
     @Override
@@ -72,7 +71,7 @@ public class YAMLPlayerMapper implements IPlayerMapper {
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, String.format("Could not delete PlayerData for %s.", player.getName()), ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.mappers.server;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
@@ -18,22 +19,21 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
-    private static MySQLServerMapper instance;
+    private final MySQLBanMapper banMapper;
 
-    public static MySQLServerMapper getInstance() {
-        if (instance == null) {
-            instance = new MySQLServerMapper();
-        }
-        return instance;
+    public MySQLServerMapper(AugmentedHardcore plugin) {
+        super(plugin);
+        this.banMapper = new MySQLBanMapper(plugin);
     }
 
     @Override
     public void insertServerDataAsync(ServerData serverData) {
-        CompletableFuture.runAsync(() -> this.updateServerData(serverData)).exceptionally(ex -> {
-            ex.printStackTrace();
+        CompletableFuture.runAsync(() -> this.updateServerData(serverData), this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not insert server data asynchronously.", ex);
             return null;
         });
     }
@@ -61,7 +61,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                     totalDeathBans = resultSet.getInt("total_death_bans");
                     String uuidString = resultSet.getString("player_uuid");
                     if (uuidString != null && !uuidString.isEmpty()) {
-                        Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance().getBanFromResultSetSync(resultSet);
+                        Pair<Integer, Ban> banPair = this.banMapper.getBanFromResultSetSync(resultSet);
                         if (banPair != null) {
                             deathBans.put(UUID.fromString(uuidString), banPair);
                         }
@@ -69,10 +69,10 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 }
                 return new ServerData(totalDeathBans, deathBans);
             } catch (SQLException | UnknownHostException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not load server data.", e);
             }
             return null;
-        });
+        }, this.plugin.getExecutor());
     }
 
     @Override
@@ -89,12 +89,12 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 preparedStatement.setInt(4, data.getTotalDeathBans());
                 preparedStatement.execute();
             } catch (SQLException | UnknownHostException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not update server data.", e);
                 return;
             }
-            data.getOngoingBans().forEach((key, value) -> MySQLBanMapper.getInstance().updateBan(this.plugin.getServer(), key, value.getBan()));
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+            data.getOngoingBans().forEach((key, value) -> this.banMapper.updateBan(this.plugin.getServer(), key, value.getBan()));
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not update server data asynchronously.", ex);
             return null;
         });
     }
@@ -110,16 +110,16 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 preparedStatement.setInt(2, this.plugin.getServer().getPort());
                 preparedStatement.execute();
             } catch (SQLException | UnknownHostException e) {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Could not delete server data.", e);
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete server data asynchronously.", ex);
             return null;
         });
     }
 
     @Override
     public void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban) {
-        MySQLBanMapper.getInstance().updateBan(null, uuid, ban);
+        this.banMapper.updateBan(null, uuid, ban);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.io.File;
@@ -19,8 +18,8 @@ import java.util.logging.Level;
 public class YAMLServerMapper implements IServerMapper {
     private final AugmentedHardcore plugin;
 
-    public YAMLServerMapper() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public YAMLServerMapper(AugmentedHardcore plugin) {
+        this.plugin = plugin;
     }
 
     private void insertServerData(ServerData data) {
@@ -31,8 +30,8 @@ public class YAMLServerMapper implements IServerMapper {
 
     @Override
     public void insertServerDataAsync(ServerData data) {
-        CompletableFuture.runAsync(() -> this.insertServerData(data)).exceptionally(ex -> {
-            ex.printStackTrace();
+        CompletableFuture.runAsync(() -> this.insertServerData(data), this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not insert server data.", ex);
             return null;
         });
     }
@@ -44,7 +43,7 @@ public class YAMLServerMapper implements IServerMapper {
 
     @Override
     public CompletableFuture<ServerData> getServerData(Server server) {
-        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(getConfig()));
+        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(getConfig()), this.plugin.getExecutor());
     }
 
     @Override
@@ -64,8 +63,8 @@ public class YAMLServerMapper implements IServerMapper {
                 //noinspection ResultOfMethodCallIgnored
                 file.delete();
             }
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete server data file.", ex);
             return null;
         });
     }
@@ -76,8 +75,8 @@ public class YAMLServerMapper implements IServerMapper {
             FileConfiguration config = this.getConfig();
             config.set("OngoingBans." + uuid, null);
             this.saveConfig(config);
-        }).exceptionally(ex -> {
-            ex.printStackTrace();
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not delete ban from server data.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -8,7 +8,6 @@ import com.backtobedrock.augmentedhardcore.mappers.server.IServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.MySQLServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.YAMLServerMapper;
 import org.bukkit.Server;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.util.UUID;
@@ -23,29 +22,31 @@ public class ServerRepository {
     //server cache
     private ServerData serverData = null;
 
-    public ServerRepository() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public ServerRepository(AugmentedHardcore plugin) {
+        this.plugin = plugin;
         this.initializeMapper();
-        this.getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban"))).exceptionally(e -> {
+        this.getServerData(this.plugin.getServer())
+                .thenAcceptAsync(serverData -> this.plugin.getLogger().log(Level.INFO, String.format("Loaded %d ongoing death %s.", serverData.getTotalOngoingBans(), serverData.getTotalOngoingBans() != 1 ? "bans" : "ban")), this.plugin.getExecutor())
+                .exceptionally(e -> {
             this.plugin.getLogger().log(Level.SEVERE, "Could not load server data asynchronously.", e);
             return null;
         });
     }
 
     private void initializeMapper() {
-        this.mapper = new YAMLServerMapper();
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLServerMapper.getInstance();
+            this.mapper = new MySQLServerMapper(this.plugin);
         } else {
-            this.mapper = new YAMLServerMapper();
+            this.mapper = new YAMLServerMapper(this.plugin);
         }
     }
 
     public CompletableFuture<ServerData> getServerData(Server server) {
         if (this.serverData == null) {
-            return this.mapper.getServerData(server).thenApplyAsync(this::getFromDataAndCache);
+            return this.mapper.getServerData(server)
+                    .thenApplyAsync(this::getFromDataAndCache, this.plugin.getExecutor());
         } else {
-            return CompletableFuture.supplyAsync(this::getFromCache);
+            return CompletableFuture.supplyAsync(this::getFromCache, this.plugin.getExecutor());
         }
     }
 

--- a/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/domain/data/PlayerDataTest.java
@@ -6,15 +6,13 @@ import com.backtobedrock.augmentedhardcore.domain.configurationDomain.Configurat
 import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationMaxHealth;
 import com.backtobedrock.augmentedhardcore.domain.configurationDomain.ConfigurationRevive;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.junit.jupiter.api.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -42,26 +40,58 @@ class PlayerDataTest {
         when(offline.getUniqueId()).thenReturn(UUID.randomUUID());
         when(offline.getName()).thenReturn("Steve");
 
-        try (MockedStatic<JavaPlugin> mocked = Mockito.mockStatic(JavaPlugin.class)) {
-            mocked.when(() -> JavaPlugin.getPlugin(AugmentedHardcore.class)).thenReturn(plugin);
+        PlayerData data = new PlayerData(
+                plugin,
+                offline,
+                "127.0.0.1",
+                LocalDateTime.of(2023,1,1,0,0),
+                3,
+                5,
+                true,
+                1200,
+                400,
+                800,
+                new TreeMap<>());
 
-            PlayerData data = new PlayerData(
-                    offline,
-                    "127.0.0.1",
-                    LocalDateTime.of(2023,1,1,0,0),
-                    3,
-                    5,
-                    true,
-                    1200,
-                    400,
-                    800,
-                    new TreeMap<>());
+        Map<String, Object> serialized = data.serialize();
+        assertEquals(3, serialized.get("Lives"));
+        assertEquals(5, serialized.get("LifeParts"));
+        assertEquals("127.0.0.1", serialized.get("LastKnownIp"));
+        assertEquals(true, serialized.get("SpectatorBanned"));
+    }
 
-            Map<String, Object> serialized = data.serialize();
-            assertEquals(3, serialized.get("Lives"));
-            assertEquals(5, serialized.get("LifeParts"));
-            assertEquals("127.0.0.1", serialized.get("LastKnownIp"));
-            assertEquals(true, serialized.get("SpectatorBanned"));
-        }
+    private AugmentedHardcore mockPluginWithConfigs(int livesAtStart, int lifePartsAtStart, int maxLives) {
+        AugmentedHardcore plugin = mock(AugmentedHardcore.class, RETURNS_DEEP_STUBS);
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        when(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getLivesAtStart()).thenReturn(livesAtStart);
+        when(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getLifePartsAtStart()).thenReturn(lifePartsAtStart);
+        when(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getMaxLives()).thenReturn(maxLives);
+        when(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getPlaytimePerLifePart()).thenReturn(0);
+        when(plugin.getConfigurations().getMaxHealthConfiguration().getPlaytimePerHalfHeart()).thenReturn(0);
+        when(plugin.getConfigurations().getReviveConfiguration().isReviveOnFirstJoin()).thenReturn(true);
+        when(plugin.getConfigurations().getReviveConfiguration().getTimeBetweenRevives()).thenReturn(0L);
+        return plugin;
+    }
+
+    @Test
+    void testInitializationUsesConfigValues() {
+        AugmentedHardcore plugin = mockPluginWithConfigs(5, 2, 10);
+        OfflinePlayer player = mock(OfflinePlayer.class);
+        PlayerData data = new PlayerData(plugin, player);
+        assertEquals(5, data.getLives());
+        assertEquals(2, data.getLifeParts());
+    }
+
+    @Test
+    void testSetLivesClampedToBounds() {
+        AugmentedHardcore plugin = mockPluginWithConfigs(3, 0, 10);
+        OfflinePlayer player = mock(OfflinePlayer.class);
+        PlayerData data = new PlayerData(plugin, player);
+
+        data.setLives(20);
+        assertEquals(10, data.getLives());
+
+        data.setLives(-5);
+        assertEquals(0, data.getLives());
     }
 }


### PR DESCRIPTION
## Summary
- replace MySQL mapper singletons with regular constructors and inject them through repositories
- log database setup failures instead of printing stack traces
- add unit tests for PlayerData initialization and life bounds

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68b34a3c0228832792f85082a513429c