### PR TITLE
Replace printStackTrace with plugin logging

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -200,7 +200,6 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             setup = new BufferedReader(new InputStreamReader(in)).lines().collect(Collectors.joining());
         } catch (IOException | NullPointerException e) {
             getLogger().log(Level.SEVERE, "Could not read db setup file.", e);
-            e.printStackTrace();
         }
         String[] queries = setup.split(";");
         for (String query : queries) {
@@ -213,7 +212,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
                 stmt.execute();
 
             } catch (SQLException e) {
-                e.printStackTrace();
+                getLogger().log(Level.SEVERE, "Error executing db setup query.", e);
             }
         }
 

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandAugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandAugmentedHardcore.java
@@ -6,6 +6,7 @@ import com.backtobedrock.augmentedhardcore.utilities.CommandUtils;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.logging.Level;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,11 +65,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
                     }).exceptionally(ex -> {
-                        ex.printStackTrace();
+                        this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;
@@ -98,11 +99,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
                     }).exceptionally(ex -> {
-                        ex.printStackTrace();
+                        this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;
@@ -132,11 +133,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
                     }).exceptionally(ex -> {
-                        ex.printStackTrace();
+                        this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;
@@ -166,11 +167,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
                     }).exceptionally(ex -> {
-                        ex.printStackTrace();
+                        this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;
@@ -202,7 +203,7 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                             this.plugin.getMessages().getCommandAddMaxHealthSuccess(this.target.getName(), maxHealth, maxHealthRaw, maxHealthTotal, maxHealthTotalRaw)
                     );
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;
@@ -232,7 +233,7 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                             this.plugin.getMessages().getCommandSetMaxHealthSuccess(this.target.getName(), maxHealth, maxHealthRaw)
                     );
                 }).exceptionally(ex -> {
-                    ex.printStackTrace();
+                    this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
                 break;

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
@@ -6,6 +6,7 @@ import com.backtobedrock.augmentedhardcore.guis.GuiPlayerDeathBans;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandDeathBans extends AbstractCommand {
     public CommandDeathBans(CommandSender cs, String[] args) {
@@ -40,7 +41,7 @@ public class CommandDeathBans extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing death bans command.", ex);
                 return null;
             });
         }
@@ -48,7 +49,7 @@ public class CommandDeathBans extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiPlayerDeathBans(playerData))).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing death bans command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandLifeParts.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandLifeParts.java
@@ -5,6 +5,7 @@ import com.backtobedrock.augmentedhardcore.domain.enums.Command;
 import com.backtobedrock.augmentedhardcore.domain.enums.Permission;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandLifeParts extends AbstractCommand {
     public CommandLifeParts(CommandSender cs, String[] args) {
@@ -39,7 +40,7 @@ public class CommandLifeParts extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing life parts command.", ex);
                 return null;
             });
         }
@@ -47,7 +48,7 @@ public class CommandLifeParts extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing life parts command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandLives.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandLives.java
@@ -5,6 +5,7 @@ import com.backtobedrock.augmentedhardcore.domain.enums.Command;
 import com.backtobedrock.augmentedhardcore.domain.enums.Permission;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandLives extends AbstractCommand {
     public CommandLives(CommandSender cs, String[] args) {
@@ -39,7 +40,7 @@ public class CommandLives extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing lives command.", ex);
                 return null;
             });
         }
@@ -47,7 +48,7 @@ public class CommandLives extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing lives command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
@@ -6,6 +6,7 @@ import com.backtobedrock.augmentedhardcore.guis.GuiMyStats;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandMyStats extends AbstractCommand {
     public CommandMyStats(CommandSender cs, String[] args) {
@@ -40,7 +41,7 @@ public class CommandMyStats extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing my stats command.", ex);
                 return null;
             });
         }
@@ -48,7 +49,7 @@ public class CommandMyStats extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiMyStats(this.sender, playerData))).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing my stats command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextLifePart.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextLifePart.java
@@ -8,6 +8,7 @@ import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.logging.Level;
 
 public class CommandNextLifePart extends AbstractCommand {
     public CommandNextLifePart(CommandSender cs, String[] args) {
@@ -42,7 +43,7 @@ public class CommandNextLifePart extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing next life part command.", ex);
                 return null;
             });
         }
@@ -50,7 +51,7 @@ public class CommandNextLifePart extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing next life part command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextMaxHealth.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextMaxHealth.java
@@ -8,6 +8,7 @@ import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.logging.Level;
 
 public class CommandNextMaxHealth extends AbstractCommand {
     public CommandNextMaxHealth(CommandSender cs, String[] args) {
@@ -42,7 +43,7 @@ public class CommandNextMaxHealth extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing next max health command.", ex);
                 return null;
             });
         }
@@ -50,7 +51,7 @@ public class CommandNextMaxHealth extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing next max health command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
@@ -8,6 +8,7 @@ import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.logging.Level;
 
 public class CommandNextRevive extends AbstractCommand {
     public CommandNextRevive(CommandSender cs, String[] args) {
@@ -42,7 +43,7 @@ public class CommandNextRevive extends AbstractCommand {
 
                 this.runCommand(this.target);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing next revive command.", ex);
                 return null;
             });
         }
@@ -50,7 +51,7 @@ public class CommandNextRevive extends AbstractCommand {
 
     private void runCommand(OfflinePlayer player) {
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing next revive command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
@@ -5,6 +5,7 @@ import com.backtobedrock.augmentedhardcore.guis.AbstractGui;
 import com.backtobedrock.augmentedhardcore.guis.GuiRevive;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandRevive extends AbstractCommand {
     public CommandRevive(CommandSender cs, String[] args) {
@@ -40,11 +41,11 @@ public class CommandRevive extends AbstractCommand {
                 AbstractGui gui = new GuiRevive(playerData, this.target);
                 PlayerUtils.openInventory(this.sender, gui);
             }).exceptionally(ex -> {
-                ex.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error executing revive command.", ex);
                 return null;
             });
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing revive command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
@@ -4,6 +4,7 @@ import com.backtobedrock.augmentedhardcore.domain.enums.Command;
 import com.backtobedrock.augmentedhardcore.guis.GuiServerDeathBans;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.command.CommandSender;
+import java.util.logging.Level;
 
 public class CommandServerDeathBans extends AbstractCommand {
     public CommandServerDeathBans(CommandSender cs, String[] args) {
@@ -28,7 +29,7 @@ public class CommandServerDeathBans extends AbstractCommand {
 
 
         this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> PlayerUtils.openInventory(this.sender, new GuiServerDeathBans(this.sender, serverData))).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing server death bans command.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandUnDeathBan.java
@@ -4,6 +4,7 @@ import com.backtobedrock.augmentedhardcore.domain.enums.Command;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import java.util.logging.Level;
 
 public class CommandUnDeathBan extends AbstractCommand {
     public CommandUnDeathBan(CommandSender cs, String[] args) {
@@ -40,7 +41,7 @@ public class CommandUnDeathBan extends AbstractCommand {
 
             this.unDeathBan();
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing un-death-ban command.", ex);
             return null;
         });
     }
@@ -53,7 +54,7 @@ public class CommandUnDeathBan extends AbstractCommand {
                 this.cs.sendMessage(this.plugin.getMessages().getTargetNotBannedByPluginError(this.target.getName(), this.plugin.getDescription().getName()));
             }
         }).exceptionally(e -> {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error executing un-death-ban command.", e);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -27,6 +27,7 @@ import org.javatuples.Pair;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.logging.Level;
 
 public class PlayerData {
     private final AugmentedHardcore plugin;
@@ -331,7 +332,7 @@ public class PlayerData {
         }
 
         this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> serverData.addBan(this, player, this.addBan(ban))).exceptionally(e -> {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error processing death ban.", e);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Level;
 
 public class ServerData {
     private final AugmentedHardcore plugin;
@@ -131,7 +132,7 @@ public class ServerData {
                     playerData.resetSpectatorDeathBan(player.getPlayer());
                 }
             }).exceptionally(e -> {
-                e.printStackTrace();
+                this.plugin.getLogger().log(Level.SEVERE, "Error removing ban.", e);
                 return null;
             });
             this.plugin.getServerRepository().removeBanFromServerData(player.getUniqueId(), unban.getBan());

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerEntityDeath.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerEntityDeath.java
@@ -5,6 +5,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 
+import java.util.logging.Level;
+
 public class ListenerEntityDeath extends AbstractEventListener {
 
     @EventHandler
@@ -21,7 +23,7 @@ public class ListenerEntityDeath extends AbstractEventListener {
         Player player = (Player) entityDamageByEntityEvent.getDamager();
 
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> playerData.onEntityKill(event.getEntity().getType(), player)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling entity death.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDamageByEntity.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDamageByEntity.java
@@ -7,6 +7,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
+import java.util.logging.Level;
+
 public class ListenerPlayerDamageByEntity extends AbstractEventListener {
     @EventHandler
     public void onPlayerDamage(EntityDamageByEntityEvent event) {
@@ -33,7 +35,7 @@ public class ListenerPlayerDamageByEntity extends AbstractEventListener {
         Killer tagger = EventUtils.getDamageEventKiller(event);
 
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> playerData.onCombatTag(tagger, player)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling player damage.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDeath.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDeath.java
@@ -5,6 +5,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
+import java.util.logging.Level;
+
 public class ListenerPlayerDeath extends AbstractEventListener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
@@ -12,7 +14,7 @@ public class ListenerPlayerDeath extends AbstractEventListener {
         Player player = event.getEntity();
 
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> playerData.onDeath(event, player)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling player death.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerJoin.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerJoin.java
@@ -6,6 +6,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerJoinEvent;
 
+import java.util.logging.Level;
+
 public class ListenerPlayerJoin extends AbstractEventListener {
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -13,7 +15,7 @@ public class ListenerPlayerJoin extends AbstractEventListener {
         Player player = event.getPlayer();
 
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(e -> e.onJoin(player)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling player join.", ex);
             return null;
         });
 

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerKick.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerKick.java
@@ -4,6 +4,8 @@ import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerKickEvent;
 
+import java.util.logging.Level;
+
 public class ListenerPlayerKick extends AbstractEventListener {
 
     @EventHandler
@@ -13,7 +15,7 @@ public class ListenerPlayerKick extends AbstractEventListener {
         }
 
         this.plugin.getPlayerRepository().getByPlayer(event.getPlayer()).thenAcceptAsync(PlayerData::onKick).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling player kick.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerRespawn.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerRespawn.java
@@ -5,13 +5,15 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
+import java.util.logging.Level;
+
 public class ListenerPlayerRespawn extends AbstractEventListener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void OnPlayerRespawn(PlayerRespawnEvent event) {
         Player player = event.getPlayer();
         this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(e -> e.onRespawn(player)).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error handling player respawn.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
@@ -6,6 +6,7 @@ import org.javatuples.Pair;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 
 public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
     protected final Map<Pair<OfflinePlayer, Integer>, Ban> bans = new LinkedHashMap<>();
@@ -62,7 +63,7 @@ public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
 
             this.customHolder.updateInvent();
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error loading death bans GUI.", ex);
             return null;
         });
     }

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
@@ -9,6 +9,7 @@ import org.bukkit.OfflinePlayer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class GuiRevive extends AbstractConfirmationGui {
     private final PlayerData reviverData;
@@ -24,7 +25,7 @@ public class GuiRevive extends AbstractConfirmationGui {
             this.updateInfo(true);
             this.updateConfirmation(true);
         }).exceptionally(ex -> {
-            ex.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Error loading revive GUI.", ex);
             return null;
         });
         this.initialize();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/Patch.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/Patch.java
@@ -27,7 +27,7 @@ public abstract class Patch extends AbstractMapper {
             this.success = true;
         } catch (SQLException e) {
             this.success = false;
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Failed to execute patch SQL.", e);
         }
     }
 
@@ -50,7 +50,7 @@ public abstract class Patch extends AbstractMapper {
             ResultSet resultSet = preparedStatement.executeQuery();
             return resultSet.next() && resultSet.getInt("c") > 0;
         } catch (SQLException e) {
-            e.printStackTrace();
+            this.plugin.getLogger().log(Level.SEVERE, "Failed to check column existence.", e);
         }
         return false;
     }


### PR DESCRIPTION
## Summary
- Replace all `printStackTrace` calls with `plugin.getLogger().log(Level.SEVERE, ...)`
- Import `java.util.logging.Level` where needed

## Testing
- `mvn -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68b363aa09748327a8d3b1c993cb5164