### PR TITLE
refactor: remove double-brace map initialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>3.4.2</version>
     <packaging>jar</packaging>
     <properties>
-        <java.version>8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <repositories>

--- a/src/com/backtobedrock/augmentedhardcore/configs/Messages.java
+++ b/src/com/backtobedrock/augmentedhardcore/configs/Messages.java
@@ -103,24 +103,20 @@ public class Messages {
     }
 
     public String getTargetNotOnlineError(String player) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-        }};
+        Map<String, String> placeholders = Map.of("player", player);
         return MessageUtils.replacePlaceholders(this.messages.getString("TargetNotOnlineError", "&c%player% is currently not online."), placeholders);
     }
 
     public String getTargetNotPlayedBeforeError(String player) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-        }};
+        Map<String, String> placeholders = Map.of("player", player);
         return MessageUtils.replacePlaceholders(this.messages.getString("TargetNotPlayedBeforeError", "&c%player% has not played on the server before."), placeholders);
     }
 
     public String getTargetNotBannedByPluginError(String player, String plugin) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("plugin", plugin);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "plugin", plugin
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("TargetNotBannedByPluginError", "&c%player% is not death banned by %plugin%."), placeholders);
     }
 
@@ -141,187 +137,181 @@ public class Messages {
     }
 
     public String getCommandAddLives(String lives, String livesRaw, String livesTotal, String livesTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("lives", lives);
-            put("livesraw", livesRaw);
-            put("livestotal", livesTotal);
-            put("livestotalraw", livesTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "lives", lives,
+                "livesraw", livesRaw,
+                "livestotal", livesTotal,
+                "livestotalraw", livesTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddLives", "&aYou've been given &e%lives%&a, you now have &e%livestotal%&a."), placeholders);
     }
 
     public String getCommandAddLivesSuccess(String player, String lives, String livesRaw, String livesTotal, String livesTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lives", lives);
-            put("livesraw", livesRaw);
-            put("livestotal", livesTotal);
-            put("livestotalraw", livesTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lives", lives,
+                "livesraw", livesRaw,
+                "livestotal", livesTotal,
+                "livestotalraw", livesTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddLivesSuccess", "&aYou successfully gave &e%lives%&a, &e%player% &anow has §e%livestotal%§a."), placeholders);
     }
 
     public String getCommandAddLifeParts(String lifeparts, String lifepartsRaw, String lifepartsTotal, String lifepartsTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("lifeparts", lifeparts);
-            put("lifepartsraw", lifepartsRaw);
-            put("lifepartstotal", lifepartsTotal);
-            put("lifepartstotalraw", lifepartsTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "lifeparts", lifeparts,
+                "lifepartsraw", lifepartsRaw,
+                "lifepartstotal", lifepartsTotal,
+                "lifepartstotalraw", lifepartsTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddLifeParts", "&aYou've been given &e%lifeparts%&a, you now have &e%lifepartstotal%&a."), placeholders);
     }
 
     public String getCommandAddLifePartsSuccess(String player, String lifeparts, String lifepartsRaw, String lifepartsTotal, String lifepartsTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lifeparts", lifeparts);
-            put("lifepartsraw", lifepartsRaw);
-            put("lifepartstotal", lifepartsTotal);
-            put("lifepartstotalraw", lifepartsTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lifeparts", lifeparts,
+                "lifepartsraw", lifepartsRaw,
+                "lifepartstotal", lifepartsTotal,
+                "lifepartstotalraw", lifepartsTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddLifePartsSuccess", "&aYou successfully gave &e%lives%&a, &e%player% &anow has §e%livesTotal%§a."), placeholders);
     }
 
     public String getCommandSetLives(String lives, String livesRaw, String livesTotal, String livesTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("lives", lives);
-            put("livesraw", livesRaw);
-            put("livestotal", livesTotal);
-            put("livestotalraw", livesTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "lives", lives,
+                "livesraw", livesRaw,
+                "livestotal", livesTotal,
+                "livestotalraw", livesTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetLives", "&aYour &elives &ahave been set to &e%livestotal%&a."), placeholders);
     }
 
     public String getCommandSetLivesSuccess(String player, String lives, String livesRaw, String livesTotal, String livesTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lives", lives);
-            put("livesraw", livesRaw);
-            put("livestotal", livesTotal);
-            put("livestotalraw", livesTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lives", lives,
+                "livesraw", livesRaw,
+                "livestotal", livesTotal,
+                "livestotalraw", livesTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetLivesSuccess", "&aYou successfully set the &elives &aof &e%player% &ato &e%livestotal%&a."), placeholders);
     }
 
     public String getCommandSetLifeParts(String lifeparts, String lifepartsRaw, String lifepartsTotal, String lifepartsTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("lifeparts", lifeparts);
-            put("lifepartsraw", lifepartsRaw);
-            put("lifepartstotal", lifepartsTotal);
-            put("lifepartstotalraw", lifepartsTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "lifeparts", lifeparts,
+                "lifepartsraw", lifepartsRaw,
+                "lifepartstotal", lifepartsTotal,
+                "lifepartstotalraw", lifepartsTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetLifeParts", "&aYour &elife parts &ahave been set to &e%lifeparts%&a, giving you &e%livestotal% &aand &e%lifepartstotal%&a."), placeholders);
     }
 
     public String getCommandSetLifePartsSuccess(String player, String lifeParts, String lifePartsRaw, String lifePartsTotal, String lifePartsTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lifeparts", lifeParts);
-            put("lifepartsraw", lifePartsRaw);
-            put("lifepartstotal", lifePartsTotal);
-            put("lifepartstotalraw", lifePartsTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lifeparts", lifeParts,
+                "lifepartsraw", lifePartsRaw,
+                "lifepartstotal", lifePartsTotal,
+                "lifepartstotalraw", lifePartsTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetLifePartsSuccess", "&aYou successfully set the &elife parts &aof &e%player% &ato &e%lifeparts%&a, &e%player% &anow has &e%livestotal% &aand &e%lifepartstotal%&a."), placeholders);
     }
 
     public String getCommandAddMaxHealth(String maxHealth, String maxHealthRaw, String maxHealthTotal, String maxHealthTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("maxhealth", maxHealth);
-            put("maxhealthraw", maxHealthRaw);
-            put("maxhealthtotal", maxHealthTotal);
-            put("maxhealthtotalraw", maxHealthTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "maxhealth", maxHealth,
+                "maxhealthraw", maxHealthRaw,
+                "maxhealthtotal", maxHealthTotal,
+                "maxhealthtotalraw", maxHealthTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddMaxHealth", "&aYou've been given &e%maxhealth%&a, you now have &e%maxhealthtotal%&a."), placeholders);
     }
 
     public String getCommandAddMaxHealthSuccess(String player, String maxHealth, String maxHealthRaw, String maxHealthTotal, String maxHealthTotalRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("maxhealth", maxHealth);
-            put("maxhealthraw", maxHealthRaw);
-            put("maxhealthtotal", maxHealthTotal);
-            put("maxhealthtotalraw", maxHealthTotalRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "maxhealth", maxHealth,
+                "maxhealthraw", maxHealthRaw,
+                "maxhealthtotal", maxHealthTotal,
+                "maxhealthtotalraw", maxHealthTotalRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandAddMaxHealthSuccess", "&aYou successfully gave &e%maxhealth%&a, &e%player% &anow has &e%maxhealthtotal%&a."), placeholders);
     }
 
     public String getCommandSetMaxHealth(String maxHealth, String maxHealthRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("maxhealth", maxHealth);
-            put("maxhealthraw", maxHealthRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "maxhealth", maxHealth,
+                "maxhealthraw", maxHealthRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetMaxHealth", "&aYour &emax health &ahas been set to &e%maxhealthraw%&a."), placeholders);
     }
 
     public String getCommandSetMaxHealthSuccess(String player, String maxHealth, String maxHealthRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("maxhealth", maxHealth);
-            put("maxhealthraw", maxHealthRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "maxhealth", maxHealth,
+                "maxhealthraw", maxHealthRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandSetMaxHealthSuccess", "&aYou successfully set the &emax health &aof &e%player%&a to &e%maxhealthraw%&a."), placeholders);
     }
 
     public String getCommandResetSuccess(String player) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-        }};
+        Map<String, String> placeholders = Map.of("player", player);
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandResetSuccess", "&aYou have successfully reset &e%player%&a."), placeholders);
     }
 
     public String getCommandReloadSuccess(String plugin) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("plugin", plugin);
-        }};
+        Map<String, String> placeholders = Map.of("plugin", plugin);
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandReloadSuccess", "&a%plugin% has successfully been reloaded."), placeholders);
     }
 
     public String getCommandLifePartsLeft(String player, String lifeParts, String lifePartsRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lifeparts", lifeParts);
-            put("lifepartsraw", lifePartsRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lifeparts", lifeParts,
+                "lifepartsraw", lifePartsRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandLifePartsLeft", "&a%player% currently has &6%lifeparts%&a."), placeholders);
     }
 
     public String getCommandLivesLeft(String player, String lives, String livesRaw) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("lives", lives);
-            put("livesraw", livesRaw);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "lives", lives,
+                "livesraw", livesRaw
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandLivesLeft", "&a%player% currently has &6%lives%&a."), placeholders);
     }
 
     public String getCommandNextLifePart(String player, String timeLeft) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("timeleft", timeLeft);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "timeleft", timeLeft
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandNextLifePart", "&a%player% will receive a new &elife part in %timeleft%&a."), placeholders);
     }
 
     public String getCommandNextMaxHealth(String player, String timeLeft) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("timeleft", timeLeft);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "timeleft", timeLeft
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandNextMaxHealth", "&a%player% will receive extra &emax health in %timeleft%&a."), placeholders);
     }
 
     public String getCommandNextRevive(String player, String timeLeft) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-            put("timeleft", timeLeft);
-        }};
+        Map<String, String> placeholders = Map.of(
+                "player", player,
+                "timeleft", timeLeft
+        );
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandNextRevive", "&a%player% will be able to &erevive in %timeleft%&a."), placeholders);
     }
 
     public String getCommandUndeathBan(String player) {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("player", player);
-        }};
+        Map<String, String> placeholders = Map.of("player", player);
         return MessageUtils.replacePlaceholders(this.messages.getString("CommandUndeathBan", "&a%player% has successfully been unbanned from a death ban."), placeholders);
     }
     //</editor-fold>

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractPaginatedGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractPaginatedGui.java
@@ -6,7 +6,6 @@ import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractPaginatedGui extends AbstractGui {
@@ -58,28 +57,28 @@ public abstract class AbstractPaginatedGui extends AbstractGui {
     }
 
     private ItemStack nextPageDisplayItem() {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("current_page", Integer.toString(currentPage));
-            put("total_pages", Integer.toString(totalPages));
-            put("next_page", Integer.toString(currentPage + 1));
-        }};
+        Map<String, String> placeholders = Map.of(
+                "current_page", Integer.toString(currentPage),
+                "total_pages", Integer.toString(totalPages),
+                "next_page", Integer.toString(currentPage + 1)
+        );
         return MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getNextPageDisplay().getItem(), placeholders);
     }
 
     private ItemStack previousPageDisplayItem() {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("current_page", Integer.toString(currentPage));
-            put("total_pages", Integer.toString(totalPages));
-            put("previous_page", Integer.toString(currentPage - 1));
-        }};
+        Map<String, String> placeholders = Map.of(
+                "current_page", Integer.toString(currentPage),
+                "total_pages", Integer.toString(totalPages),
+                "previous_page", Integer.toString(currentPage - 1)
+        );
         return MessageUtils.replaceItemLorePlacholders(this.plugin.getConfigurations().getGuisConfiguration().getPreviousPageDisplay().getItem(), placeholders);
     }
 
     private ItemStack pageInformationDisplayItem() {
-        Map<String, String> placeholders = new HashMap<String, String>() {{
-            put("current_page", Integer.toString(currentPage));
-            put("total_pages", Integer.toString(totalPages));
-        }};
+        Map<String, String> placeholders = Map.of(
+                "current_page", Integer.toString(currentPage),
+                "total_pages", Integer.toString(totalPages)
+        );
         return MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getPageInformationDisplay().getItem(), placeholders);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiMyStats.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiMyStats.java
@@ -70,14 +70,14 @@ public class GuiMyStats extends AbstractGui {
         if (!this.plugin.getConfigurations().getMaxHealthConfiguration().isUseMaxHealth()) {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getNotAvailableDisplay().getItem(), Collections.emptyList());
         } else {
-            Map<String, String> placeholders = new HashMap<String, String>() {{
-                put("max_health", Double.toString(plugin.getConfigurations().getMaxHealthConfiguration().getMaxHealth()));
-                put("min_health", Double.toString(plugin.getConfigurations().getMaxHealthConfiguration().getMinHealth()));
-                put("current_max_health", playerData.getPlayer().getPlayer() == null ? "-" : Double.toString(playerData.getPlayer().getPlayer().getAttribute(Attribute.MAX_HEALTH).getBaseValue()));
-                put("time_till_next_max_health_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.LONG));
-                put("time_till_next_max_health_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.SHORT));
-                put("time_till_next_max_health_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.DIGITAL));
-            }};
+            Map<String, String> placeholders = Map.of(
+                    "max_health", Double.toString(plugin.getConfigurations().getMaxHealthConfiguration().getMaxHealth()),
+                    "min_health", Double.toString(plugin.getConfigurations().getMaxHealthConfiguration().getMinHealth()),
+                    "current_max_health", playerData.getPlayer().getPlayer() == null ? "-" : Double.toString(playerData.getPlayer().getPlayer().getAttribute(Attribute.MAX_HEALTH).getBaseValue()),
+                    "time_till_next_max_health_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.LONG),
+                    "time_till_next_max_health_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.SHORT),
+                    "time_till_next_max_health_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextMaxHealth(), TimePattern.DIGITAL)
+            );
 
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getMaxHealthDisplay().getItem(), placeholders), Collections.emptyList());
         }
@@ -90,11 +90,11 @@ public class GuiMyStats extends AbstractGui {
         if (!this.plugin.getConfigurations().getReviveConfiguration().isUseRevive() || this.isOther) {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getNotAvailableDisplay().getItem(), Collections.emptyList());
         } else if (this.playerData.getTimeTillNextRevive() > 0 && !this.sender.hasPermission(Permission.BYPASS_REVIVECOOLDOWN.getPermissionString())) {
-            Map<String, String> placeholders = new HashMap<String, String>() {{
-                put("time_till_next_revive_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.LONG));
-                put("time_till_next_revive_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.SHORT));
-                put("time_till_next_revive_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.DIGITAL));
-            }};
+            Map<String, String> placeholders = Map.of(
+                    "time_till_next_revive_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.LONG),
+                    "time_till_next_revive_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.SHORT),
+                    "time_till_next_revive_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.DIGITAL)
+            );
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getReviveOnCooldownDisplay().getItem(), placeholders), Collections.emptyList());
         } else {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getReviveDisplay().getItem(), Collections.singletonList(new ClickActionOpenPlayerSelectionAnvilGui()));
@@ -109,14 +109,14 @@ public class GuiMyStats extends AbstractGui {
         if (!this.plugin.getConfigurations().getLivesAndLifePartsConfiguration().isUseLifeParts()) {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getNotAvailableDisplay().getItem(), Collections.emptyList());
         } else {
-            Map<String, String> placeholders = new HashMap<String, String>() {{
-                put("max_life_parts", Integer.toString(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getMaxLifeParts()));
-                put("life_parts_number", Integer.toString(playerData.getLifeParts()));
-                put("life_parts", String.format("%d %s", playerData.getLifeParts(), playerData.getLifeParts() == 1 ? "life part" : "life parts"));
-                put("time_till_next_life_part_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.LONG));
-                put("time_till_next_life_part_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.SHORT));
-                put("time_till_next_life_part_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.DIGITAL));
-            }};
+            Map<String, String> placeholders = Map.of(
+                    "max_life_parts", Integer.toString(plugin.getConfigurations().getLivesAndLifePartsConfiguration().getMaxLifeParts()),
+                    "life_parts_number", Integer.toString(playerData.getLifeParts()),
+                    "life_parts", String.format("%d %s", playerData.getLifeParts(), playerData.getLifeParts() == 1 ? "life part" : "life parts"),
+                    "time_till_next_life_part_long", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.LONG),
+                    "time_till_next_life_part_short", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.SHORT),
+                    "time_till_next_life_part_digital", MessageUtils.getTimeFromTicks(playerData.getTimeTillNextLifePart(), TimePattern.DIGITAL)
+            );
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getLifePartDisplay().getItem(), placeholders), Collections.emptyList());
         }
 
@@ -129,9 +129,9 @@ public class GuiMyStats extends AbstractGui {
         if (!this.plugin.getConfigurations().getDeathBanConfiguration().isUseDeathBan()) {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getNotAvailableDisplay().getItem(), Collections.emptyList());
         } else {
-            Map<String, String> placeholders = new HashMap<String, String>() {{
-                put("total_death_bans", Integer.toString(playerData.getBanCount()));
-            }};
+            Map<String, String> placeholders = Map.of(
+                    "total_death_bans", Integer.toString(playerData.getBanCount())
+            );
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getPreviousBansDisplay().getItem(), placeholders), Collections.singletonList(new ClickActionOpenBansGui(this.playerData)));
         }
 

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
@@ -7,7 +7,6 @@ import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
@@ -41,10 +40,10 @@ public class GuiRevive extends AbstractConfirmationGui {
     public void updateInfo(boolean update) {
         Icon icon;
         if (this.revivingData != null) {
-            Map<String, String> placeholders = new HashMap<String, String>() {{
-                put("player", revivingData.getPlayer().getName());
-                put("lives_number", Integer.toString(revivingData.getLives()));
-            }};
+            Map<String, String> placeholders = Map.of(
+                    "player", revivingData.getPlayer().getName(),
+                    "lives_number", Integer.toString(revivingData.getLives())
+            );
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(InventoryUtils.createPlayerSkull(this.plugin.getConfigurations().getGuisConfiguration().getRevivingDisplay().getName(), this.plugin.getConfigurations().getGuisConfiguration().getRevivingDisplay().getLore(), this.reviving), placeholders), Collections.emptyList());
         } else {
             icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getLoadingDisplay().getItem(), Collections.emptyList());


### PR DESCRIPTION
## Summary
- replace anonymous double-brace maps in GUI classes with `Map.of` placeholders
- cleanup `Messages` config by using `Map.of` for small placeholder maps
- target Java 17 for Map.of support

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b37606edb483278e1d9cd15abb834d