### PR TITLE
Use plugin executor for command async tasks

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/commands/AbstractCommand.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/AbstractCommand.java
@@ -76,7 +76,7 @@ public abstract class AbstractCommand {
             }
             this.target = player;
             return true;
-        });
+        }, this.plugin.getExecutor());
     }
 
     public void sendUsageMessage(Command command) {

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandAugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandAugmentedHardcore.java
@@ -64,11 +64,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                         );
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
-                    }).exceptionally(ex -> {
+                    }, this.plugin.getExecutor()).exceptionally(ex -> {
                         this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -98,11 +98,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                         );
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
-                    }).exceptionally(ex -> {
+                    }, this.plugin.getExecutor()).exceptionally(ex -> {
                         this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -132,11 +132,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                         );
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
-                    }).exceptionally(ex -> {
+                    }, this.plugin.getExecutor()).exceptionally(ex -> {
                         this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -166,11 +166,11 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                         );
 
                         this.plugin.getPlayerRepository().updatePlayerData(playerData);
-                    }).exceptionally(ex -> {
+                    }, this.plugin.getExecutor()).exceptionally(ex -> {
                         this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                         return null;
                     });
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -202,7 +202,7 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                             this.plugin.getMessages().getCommandAddMaxHealth(maxHealth, maxHealthRaw, maxHealthTotal, maxHealthTotalRaw),
                             this.plugin.getMessages().getCommandAddMaxHealthSuccess(this.target.getName(), maxHealth, maxHealthRaw, maxHealthTotal, maxHealthTotalRaw)
                     );
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -232,7 +232,7 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                             this.plugin.getMessages().getCommandSetMaxHealth(maxHealth, maxHealthRaw),
                             this.plugin.getMessages().getCommandSetMaxHealthSuccess(this.target.getName(), maxHealth, maxHealthRaw)
                     );
-                }).exceptionally(ex -> {
+                }, this.plugin.getExecutor()).exceptionally(ex -> {
                     this.plugin.getLogger().log(Level.SEVERE, "Error executing AugmentedHardcore command.", ex);
                     return null;
                 });
@@ -247,8 +247,8 @@ public class CommandAugmentedHardcore extends AbstractCommand {
                         playerData.reset();
 
                         this.cs.sendMessage(this.plugin.getMessages().getCommandResetSuccess(this.target.getName()));
-                    });
-                });
+                    }, this.plugin.getExecutor());
+                }, this.plugin.getExecutor());
                 break;
             case RELOAD:
                 this.plugin.initialize();

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
@@ -40,7 +40,7 @@ public class CommandDeathBans extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing death bans command.", ex);
                 return null;
             });
@@ -48,7 +48,7 @@ public class CommandDeathBans extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiPlayerDeathBans(playerData))).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiPlayerDeathBans(playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing death bans command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandLifeParts.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandLifeParts.java
@@ -39,7 +39,7 @@ public class CommandLifeParts extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing life parts command.", ex);
                 return null;
             });
@@ -47,7 +47,7 @@ public class CommandLifeParts extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing life parts command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandLives.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandLives.java
@@ -39,7 +39,7 @@ public class CommandLives extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing lives command.", ex);
                 return null;
             });
@@ -47,7 +47,7 @@ public class CommandLives extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing lives command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
@@ -40,7 +40,7 @@ public class CommandMyStats extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing my stats command.", ex);
                 return null;
             });
@@ -48,7 +48,7 @@ public class CommandMyStats extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiMyStats(this.sender, playerData))).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiMyStats(this.sender, playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing my stats command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextLifePart.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextLifePart.java
@@ -42,7 +42,7 @@ public class CommandNextLifePart extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing next life part command.", ex);
                 return null;
             });
@@ -50,7 +50,7 @@ public class CommandNextLifePart extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing next life part command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextMaxHealth.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextMaxHealth.java
@@ -42,7 +42,7 @@ public class CommandNextMaxHealth extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing next max health command.", ex);
                 return null;
             });
@@ -50,7 +50,7 @@ public class CommandNextMaxHealth extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing next max health command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
@@ -42,7 +42,7 @@ public class CommandNextRevive extends AbstractCommand {
                 }
 
                 this.runCommand(this.target);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing next revive command.", ex);
                 return null;
             });
@@ -50,7 +50,7 @@ public class CommandNextRevive extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(this::sendSuccessMessage, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing next revive command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
@@ -40,11 +40,11 @@ public class CommandRevive extends AbstractCommand {
 
                 AbstractGui gui = new GuiRevive(playerData, this.target);
                 PlayerUtils.openInventory(this.sender, gui);
-            }).exceptionally(ex -> {
+            }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing revive command.", ex);
                 return null;
             });
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing revive command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
@@ -28,7 +28,7 @@ public class CommandServerDeathBans extends AbstractCommand {
         }
 
 
-        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> PlayerUtils.openInventory(this.sender, new GuiServerDeathBans(this.sender, serverData))).exceptionally(ex -> {
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> PlayerUtils.openInventory(this.sender, new GuiServerDeathBans(this.sender, serverData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing server death bans command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandUnDeathBan.java
@@ -40,7 +40,7 @@ public class CommandUnDeathBan extends AbstractCommand {
             }
 
             this.unDeathBan();
-        }).exceptionally(ex -> {
+        }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing un-death-ban command.", ex);
             return null;
         });
@@ -53,7 +53,7 @@ public class CommandUnDeathBan extends AbstractCommand {
             } else {
                 this.cs.sendMessage(this.plugin.getMessages().getTargetNotBannedByPluginError(this.target.getName(), this.plugin.getDescription().getName()));
             }
-        }).exceptionally(e -> {
+        }, this.plugin.getExecutor()).exceptionally(e -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing un-death-ban command.", e);
             return null;
         });


### PR DESCRIPTION
## Summary
- use plugin-provided executor in `AbstractCommand.hasPlayedBefore`
- run all command asynchronous completions with the plugin executor

## Testing
- `mvn -q -e -DskipTests package` *(failed: Could not resolve maven-resources-plugin due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3783f3ee08327a791725cdb245f03