### PR TITLE
Use Optional results instead of sentinel values

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationCombatTag.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationCombatTag.java
@@ -4,6 +4,7 @@ import com.backtobedrock.augmentedhardcore.utilities.ConfigUtils;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 public class ConfigurationCombatTag {
     private final boolean combatTagSelf;
@@ -33,11 +34,11 @@ public class ConfigurationCombatTag {
         boolean cPlayerCombatTag = section.getBoolean("PlayerCombatTag", true);
         boolean cMonsterCombatTag = section.getBoolean("MonsterCombatTag", true);
         boolean cCombatTagSelf = section.getBoolean("CombatTagSelf", true);
-        int cCombatTagTime = ConfigUtils.checkMinMax("CombatTagTime", section.getInt("CombatTagTime", 15), 1, Integer.MAX_VALUE);
+        OptionalInt cCombatTagTime = ConfigUtils.checkMinMax("CombatTagTime", section.getInt("CombatTagTime", 15), 1, Integer.MAX_VALUE);
         boolean cCombatTagPlayerKickDeath = section.getBoolean("CombatTagPlayerKickDeath", true);
         List<String> cDisableCombatTagInWorlds = section.getStringList("DisableCombatTagInWorlds");
 
-        if (cCombatTagTime == -10) {
+        if (cCombatTagTime.isEmpty()) {
             return null;
         }
 
@@ -45,7 +46,7 @@ public class ConfigurationCombatTag {
                 cPlayerCombatTag,
                 cMonsterCombatTag,
                 cCombatTagSelf,
-                cCombatTagTime,
+                cCombatTagTime.getAsInt(),
                 cCombatTagPlayerKickDeath,
                 cDisableCombatTagInWorlds
         );

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationLivesAndLifeParts.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationLivesAndLifeParts.java
@@ -8,6 +8,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.EnumMap;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.logging.Level;
 
 public class ConfigurationLivesAndLifeParts {
@@ -83,24 +84,24 @@ public class ConfigurationLivesAndLifeParts {
     public static ConfigurationLivesAndLifeParts deserialize(ConfigurationSection section) {
         //lives
         boolean cUseLives = section.getBoolean("UseLives", true);
-        int cMaxLives = ConfigUtils.checkMinMax("MaxLives", section.getInt("MaxLives", 5), 1, Integer.MAX_VALUE);
-        int cLivesAtStart = ConfigUtils.checkMinMax("LivesAtStart", section.getInt("LivesAtStart", 1), 1, Integer.MAX_VALUE);
-        int cLivesAfterBan = ConfigUtils.checkMinMax("LivesAfterBan", section.getInt("LivesAfterBan", 1), 1, Integer.MAX_VALUE);
-        int cLivesLostPerDeath = ConfigUtils.checkMinMax("LivesLostPerDeath", section.getInt("LivesLostPerDeath", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cMaxLives = ConfigUtils.checkMinMax("MaxLives", section.getInt("MaxLives", 5), 1, Integer.MAX_VALUE);
+        OptionalInt cLivesAtStart = ConfigUtils.checkMinMax("LivesAtStart", section.getInt("LivesAtStart", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cLivesAfterBan = ConfigUtils.checkMinMax("LivesAfterBan", section.getInt("LivesAfterBan", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cLivesLostPerDeath = ConfigUtils.checkMinMax("LivesLostPerDeath", section.getInt("LivesLostPerDeath", 1), 1, Integer.MAX_VALUE);
         List<String> cDisableLosingLivesInWorlds = section.getStringList("DisableLosingLivesInWorlds").stream().map(String::toLowerCase).toList();
 
         //life parts
         boolean cUseLifeParts = section.getBoolean("UseLifeParts", true);
-        int cMaxLifeParts = ConfigUtils.checkMinMax("MaxLifeParts", section.getInt("MaxLifeParts", 6), -1, Integer.MAX_VALUE);
-        int cLifePartsPerLife = ConfigUtils.checkMinMax("LifePartsPerLife", section.getInt("LifePartsPerLife"), 1, Integer.MAX_VALUE);
-        int cLifePartsAtStart = ConfigUtils.checkMinMax("LifePartsAtStart", section.getInt("LifePartsAtStart"), 0, Integer.MAX_VALUE);
-        int cLifePartsAfterBan = ConfigUtils.checkMinMax("LifePartsAfterBan", section.getInt("LifePartsAfterBan"), -1, Integer.MAX_VALUE);
-        int cLifePartsLostPerDeath = ConfigUtils.checkMinMax("LifePartsLostPerDeath", section.getInt("LifePartsLostPerDeath", 1), -1, Integer.MAX_VALUE);
-        int cLifePartsLostPerDeathBan = ConfigUtils.checkMinMax("LifePartsLostPerDeathBan", section.getInt("LifePartsLostPerDeathBan", -1), -1, Integer.MAX_VALUE);
+        OptionalInt cMaxLifeParts = ConfigUtils.checkMinMax("MaxLifeParts", section.getInt("MaxLifeParts", 6), -1, Integer.MAX_VALUE);
+        OptionalInt cLifePartsPerLife = ConfigUtils.checkMinMax("LifePartsPerLife", section.getInt("LifePartsPerLife"), 1, Integer.MAX_VALUE);
+        OptionalInt cLifePartsAtStart = ConfigUtils.checkMinMax("LifePartsAtStart", section.getInt("LifePartsAtStart"), 0, Integer.MAX_VALUE);
+        OptionalInt cLifePartsAfterBan = ConfigUtils.checkMinMax("LifePartsAfterBan", section.getInt("LifePartsAfterBan"), -1, Integer.MAX_VALUE);
+        OptionalInt cLifePartsLostPerDeath = ConfigUtils.checkMinMax("LifePartsLostPerDeath", section.getInt("LifePartsLostPerDeath", 1), -1, Integer.MAX_VALUE);
+        OptionalInt cLifePartsLostPerDeathBan = ConfigUtils.checkMinMax("LifePartsLostPerDeathBan", section.getInt("LifePartsLostPerDeathBan", -1), -1, Integer.MAX_VALUE);
         boolean cLifePartsOnKill = section.getBoolean("LifePartsOnKill");
         EnumMap<EntityType, Integer> cLifePartsPerKill = new EnumMap<>(EntityType.class);
         boolean cGetLifePartsByPlaytime = section.getBoolean("GetLifePartByPlaytime", false);
-        int cPlaytimePerLifePart = ConfigUtils.checkMinMax("PlaytimePerLifePart", section.getInt("PlaytimePerLifePart", 30), 1, Integer.MAX_VALUE);
+        OptionalInt cPlaytimePerLifePart = ConfigUtils.checkMinMax("PlaytimePerLifePart", section.getInt("PlaytimePerLifePart", 30), 1, Integer.MAX_VALUE);
         List<String> cDisableGainingLifePartsInWorlds = section.getStringList("DisableGainingLifePartsInWorlds").stream().map(String::toLowerCase).toList();
         List<String> cDisableLosingLifePartsInWorlds = section.getStringList("DisableLosingLifePartsInWorlds").stream().map(String::toLowerCase).toList();
 
@@ -109,14 +110,14 @@ public class ConfigurationLivesAndLifeParts {
         }
 
         //if cLifePartsLostPerDeath or cLifePartsLostPerDeathBan == -1 then set to max Integer.
-        if (cLifePartsLostPerDeath == -1) {
-            cLifePartsLostPerDeath = Integer.MAX_VALUE;
+        if (cLifePartsLostPerDeath.isPresent() && cLifePartsLostPerDeath.getAsInt() == -1) {
+            cLifePartsLostPerDeath = OptionalInt.of(Integer.MAX_VALUE);
         }
-        if (cLifePartsLostPerDeathBan == -1) {
-            cLifePartsLostPerDeathBan = Integer.MAX_VALUE;
+        if (cLifePartsLostPerDeathBan.isPresent() && cLifePartsLostPerDeathBan.getAsInt() == -1) {
+            cLifePartsLostPerDeathBan = OptionalInt.of(Integer.MAX_VALUE);
         }
-        if (cMaxLifeParts == -1) {
-            cMaxLifeParts = Integer.MAX_VALUE;
+        if (cMaxLifeParts.isPresent() && cMaxLifeParts.getAsInt() == -1) {
+            cMaxLifeParts = OptionalInt.of(Integer.MAX_VALUE);
         }
 
         ConfigurationSection lifePartsPerKillSection = section.getConfigurationSection("LifePartsPerKill");
@@ -124,37 +125,48 @@ public class ConfigurationLivesAndLifeParts {
             lifePartsPerKillSection.getKeys(false).forEach(e -> {
                 EntityType type = ConfigUtils.getLivingEntityType("LifePartsPerKill", e);
                 if (type != null) {
-                    int amount = ConfigUtils.checkMin("LifePartsPerKill." + e, lifePartsPerKillSection.getInt(e, 0), 0);
-                    if (amount != -10)
-                        cLifePartsPerKill.put(type, amount);
+                    OptionalInt amount = ConfigUtils.checkMin("LifePartsPerKill." + e, lifePartsPerKillSection.getInt(e, 0), 0);
+                    amount.ifPresent(a -> cLifePartsPerKill.put(type, a));
                 }
             });
         }
 
-        if (cMaxLives == -10 || cLivesAtStart == -10 || cLivesAfterBan == -10 || cLivesLostPerDeath == -10 || cMaxLifeParts == -10 || cLifePartsPerLife == -10 || cLifePartsAtStart == -10 || cLifePartsAfterBan == -10 || cLifePartsLostPerDeath == -10 || cLifePartsLostPerDeathBan == -10 || cPlaytimePerLifePart == -10) {
+        if (cMaxLives.isEmpty() || cLivesAtStart.isEmpty() || cLivesAfterBan.isEmpty() || cLivesLostPerDeath.isEmpty() || cMaxLifeParts.isEmpty() || cLifePartsPerLife.isEmpty() || cLifePartsAtStart.isEmpty() || cLifePartsAfterBan.isEmpty() || cLifePartsLostPerDeath.isEmpty() || cLifePartsLostPerDeathBan.isEmpty() || cPlaytimePerLifePart.isEmpty()) {
             return null;
         }
+
+        int vMaxLives = cMaxLives.getAsInt();
+        int vLivesAtStart = cLivesAtStart.getAsInt();
+        int vLivesAfterBan = cLivesAfterBan.getAsInt();
+        int vLivesLostPerDeath = cLivesLostPerDeath.getAsInt();
+        int vMaxLifeParts = cMaxLifeParts.getAsInt();
+        int vLifePartsPerLife = cLifePartsPerLife.getAsInt();
+        int vLifePartsAtStart = cLifePartsAtStart.getAsInt();
+        int vLifePartsAfterBan = cLifePartsAfterBan.getAsInt();
+        int vLifePartsLostPerDeath = cLifePartsLostPerDeath.getAsInt();
+        int vLifePartsLostPerDeathBan = cLifePartsLostPerDeathBan.getAsInt();
+        int vPlaytimePerLifePart = cPlaytimePerLifePart.getAsInt();
 
         return new ConfigurationLivesAndLifeParts(
                 //lives
                 cUseLives,
-                cMaxLives,
-                cLivesAtStart,
-                cLivesAfterBan,
-                cLivesLostPerDeath,
+                vMaxLives,
+                vLivesAtStart,
+                vLivesAfterBan,
+                vLivesLostPerDeath,
                 cDisableLosingLivesInWorlds,
                 //life parts
                 cUseLifeParts,
-                cMaxLifeParts,
-                cLifePartsPerLife,
-                cLifePartsAtStart,
-                cLifePartsAfterBan,
-                cLifePartsLostPerDeath,
-                cLifePartsLostPerDeathBan,
+                vMaxLifeParts,
+                vLifePartsPerLife,
+                vLifePartsAtStart,
+                vLifePartsAfterBan,
+                vLifePartsLostPerDeath,
+                vLifePartsLostPerDeathBan,
                 cLifePartsOnKill,
                 cLifePartsPerKill,
                 cGetLifePartsByPlaytime,
-                cPlaytimePerLifePart * 1200,
+                vPlaytimePerLifePart * 1200,
                 cDisableGainingLifePartsInWorlds,
                 cDisableLosingLifePartsInWorlds
         );

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
@@ -4,6 +4,7 @@ import com.backtobedrock.augmentedhardcore.utilities.ConfigUtils;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 public class ConfigurationRevive {
     private final boolean useRevive;
@@ -24,21 +25,21 @@ public class ConfigurationRevive {
 
     public static ConfigurationRevive deserialize(ConfigurationSection section) {
         boolean cUseRevive = section.getBoolean("UseRevive", true);
-        int cLivesLostOnReviving = ConfigUtils.checkMinMax("LivesLostOnReviving", section.getInt("LivesLostOnReviving", 1), 1, Integer.MAX_VALUE);
-        int cLivesGainedOnRevive = ConfigUtils.checkMinMax("LivesGainedOnRevive", section.getInt("LivesGainedOnRevive", 1), 1, Integer.MAX_VALUE);
-        int cTimeBetweenRevives = ConfigUtils.checkMinMax("TimeBetweenRevives", section.getInt("TimeBetweenRevives", 1440), 0, Integer.MAX_VALUE);
+        OptionalInt cLivesLostOnReviving = ConfigUtils.checkMinMax("LivesLostOnReviving", section.getInt("LivesLostOnReviving", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cLivesGainedOnRevive = ConfigUtils.checkMinMax("LivesGainedOnRevive", section.getInt("LivesGainedOnRevive", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cTimeBetweenRevives = ConfigUtils.checkMinMax("TimeBetweenRevives", section.getInt("TimeBetweenRevives", 1440), 0, Integer.MAX_VALUE);
         boolean cReviveOnFirstJoin = section.getBoolean("ReviveOnFirstJoin", false);
         List<String> cDisableReviveInWorlds = section.getStringList("DisableReviveInWorlds").stream().map(String::toLowerCase).toList();
 
-        if (cTimeBetweenRevives == -10 || cLivesLostOnReviving == -10 || cLivesGainedOnRevive == -10) {
+        if (cTimeBetweenRevives.isEmpty() || cLivesLostOnReviving.isEmpty() || cLivesGainedOnRevive.isEmpty()) {
             return null;
         }
 
         return new ConfigurationRevive(
                 cUseRevive,
-                cLivesLostOnReviving,
-                cLivesGainedOnRevive,
-                cTimeBetweenRevives * 1200,
+                cLivesLostOnReviving.getAsInt(),
+                cLivesGainedOnRevive.getAsInt(),
+                cTimeBetweenRevives.getAsInt() * 1200,
                 cReviveOnFirstJoin,
                 cDisableReviveInWorlds
         );

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/BanConfiguration.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/BanConfiguration.java
@@ -7,6 +7,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.logging.Level;
 
 public class BanConfiguration {
@@ -21,7 +22,7 @@ public class BanConfiguration {
     public static BanConfiguration deserialize(DamageCause cause, ConfigurationSection section) {
         AugmentedHardcore plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
 
-        int cBanTime = ConfigUtils.checkMinMaxNoNotification(section.getInt("BanTime", cause.getDefaultBantime()), -1, Integer.MAX_VALUE);
+        OptionalInt cBanTime = ConfigUtils.checkMinMaxNoNotification(section.getInt("BanTime", cause.getDefaultBantime()), -1, Integer.MAX_VALUE);
         List<String> cDisplayMessages = section.contains("DisplayMessages") ? section.getStringList("DisplayMessages") : null;
 
         if (cDisplayMessages == null) {
@@ -29,12 +30,12 @@ public class BanConfiguration {
             plugin.getLogger().log(Level.SEVERE, String.format("DeathCauseConfigurations: %s didn't have correct DisplayMessages configured and default value will be used: %s.", cause.name(), cause.getDefaultDisplayMessages().toString()));
         }
 
-        if (cBanTime == -10) {
-            cBanTime = cause.getDefaultBantime();
+        int banTime = cBanTime.orElse(cause.getDefaultBantime());
+        if (cBanTime.isEmpty()) {
             plugin.getLogger().log(Level.SEVERE, String.format("DeathCauseConfigurations: %s didn't have a correct BanTime configured and default value will be used: %d.", cause.name(), cause.getDefaultBantime()));
         }
 
-        return new BanConfiguration(cBanTime, cDisplayMessages);
+        return new BanConfiguration(banTime, cDisplayMessages);
     }
 
     public int getBanTime() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/Display.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/Display.java
@@ -11,6 +11,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.logging.Level;
 
 public class Display {
@@ -32,18 +33,18 @@ public class Display {
         Material cMaterial = ConfigUtils.getMaterial(id + ".Material", section.getString("Material"));
         String cName = section.getString("Name");
         List<String> cLore = section.getStringList("Lore");
-        int cAmount = ConfigUtils.checkMinMax(id + ".Amount", section.getInt("Amount", 1), 1, Integer.MAX_VALUE);
+        OptionalInt cAmount = ConfigUtils.checkMinMax(id + ".Amount", section.getInt("Amount", 1), 1, Integer.MAX_VALUE);
 
         if (cName == null) {
             plugin.getLogger().log(Level.SEVERE, id + ".Name: %s is not a valid name.");
             return null;
         }
 
-        if (cAmount == -10 || cMaterial == null) {
+        if (cAmount.isEmpty() || cMaterial == null) {
             return null;
         }
 
-        return new Display(cMaterial, cName, cLore, cAmount);
+        return new Display(cMaterial, cName, cLore, cAmount.getAsInt());
     }
 
     public ItemStack getItem() {

--- a/src/com/backtobedrock/augmentedhardcore/utilities/ConfigUtils.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/ConfigUtils.java
@@ -9,50 +9,52 @@ import org.bukkit.boss.BarStyle;
 import org.bukkit.entity.EntityType;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 import java.util.logging.Level;
 
 public class ConfigUtils {
-    public static int checkMin(String id, int value, int min) {
+    public static OptionalInt checkMin(String id, int value, int min) {
         if (value >= min) {
-            return value;
+            return OptionalInt.of(value);
         } else {
             sendErrorMessage(String.format("%s: value cannot be lower than %d, your value is: %d", id, min, value));
-            return -10;
+            return OptionalInt.empty();
         }
     }
 
-    public static int checkMinMaxNoNotification(int value, int min, int max) {
+    public static OptionalInt checkMinMaxNoNotification(int value, int min, int max) {
         if (value >= min && value <= max) {
-            return value;
+            return OptionalInt.of(value);
         } else {
-            return -10;
+            return OptionalInt.empty();
         }
     }
 
-    public static double checkMin(String id, double value, double min) {
+    public static OptionalDouble checkMin(String id, double value, double min) {
         if (value >= min) {
-            return value;
+            return OptionalDouble.of(value);
         } else {
             sendErrorMessage(String.format("%s: value cannot be lower than %f, your value is: %f", id, min, value));
-            return -10;
+            return OptionalDouble.empty();
         }
     }
 
-    public static double checkMinMax(String id, double value, double min, double max) {
+    public static OptionalDouble checkMinMax(String id, double value, double min, double max) {
         if (value >= min && value <= max) {
-            return value;
+            return OptionalDouble.of(value);
         } else {
             sendErrorMessage(String.format("%s: value cannot be lower than %f and higher than %f, your value is: %f", id, min, max, value));
-            return -10;
+            return OptionalDouble.empty();
         }
     }
 
-    public static int checkMinMax(String id, int value, int min, int max) {
+    public static OptionalInt checkMinMax(String id, int value, int min, int max) {
         if (value >= min && value <= max) {
-            return value;
+            return OptionalInt.of(value);
         } else {
             sendErrorMessage(String.format("%s: value cannot be lower than %d and higher than %d, your value is: %d", id, min, max, value));
-            return -10;
+            return OptionalInt.empty();
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace `-10` return values with `OptionalInt`/`OptionalDouble` in `ConfigUtils`
- Adjust configuration deserializers to use optionals instead of sentinel checks
- Default invalid ban times to configured defaults

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to maven-central (https://repo1.maven.org/maven2/): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b37fbe7ee483279047f1ba232d0fdf