### PR TITLE
Stop update checker on plugin disable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,5 +130,17 @@
             <version>7.0.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.seeseemelk</groupId>
+            <artifactId>MockBukkit-v1.21</artifactId>
+            <version>1.21-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -91,6 +91,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
             }
         }
 
+        if (this.updateChecker != null) {
+            this.updateChecker.stop();
+        }
+
         if (this.executor != null) {
             this.executor.shutdown();
         }

--- a/src/test/java/com/backtobedrock/augmentedhardcore/runnables/UpdateCheckerTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/runnables/UpdateCheckerTest.java
@@ -1,0 +1,43 @@
+package com.backtobedrock.augmentedhardcore.runnables;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+public class UpdateCheckerTest {
+
+    private ServerMock server;
+    private AugmentedHardcore plugin;
+
+    @BeforeEach
+    void setUp() {
+        this.server = MockBukkit.mock();
+        this.plugin = MockBukkit.load(AugmentedHardcore.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testUpdateCheckerCancelledOnDisable() throws Exception {
+        Field field = AugmentedHardcore.class.getDeclaredField("updateChecker");
+        field.setAccessible(true);
+        UpdateChecker checker = (UpdateChecker) field.get(this.plugin);
+        int taskId = checker.getTaskId();
+
+        Assertions.assertTrue(this.server.getScheduler().isQueued(taskId));
+
+        this.plugin.onDisable();
+
+        Assertions.assertTrue(checker.isCancelled());
+        Assertions.assertFalse(this.server.getScheduler().isQueued(taskId));
+    }
+}


### PR DESCRIPTION
## Summary
- stop UpdateChecker when plugin disables and guard against null
- add testing dependencies and a test ensuring UpdateChecker tasks are cancelled on disable

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b391de55388327afef919dc17d200a