### PR TITLE
Log ConfigUtils warnings at WARNING level

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/utilities/ConfigUtils.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/ConfigUtils.java
@@ -205,6 +205,6 @@ public class ConfigUtils {
 
     private static void sendWarningMessage(String message) {
         AugmentedHardcore plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
-        plugin.getLogger().log(Level.INFO, message);
+        plugin.getLogger().log(Level.WARNING, message);
     }
 }


### PR DESCRIPTION
## Summary
- Log ConfigUtils warnings using `Level.WARNING` instead of `Level.INFO`
- Confirm no current usage of `sendWarningMessage`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b39f8579e08327b992d91a84dacca4