### PR TITLE
refactor: remove singleton mappers

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -188,6 +188,8 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         }
         if (this.serverRepository == null) {
             this.serverRepository = new ServerRepository(this);
+        } else {
+            this.serverRepository.onReload();
         }
 
         //register event listeners

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -17,16 +17,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
-    private static MySQLBanMapper instance;
-
-    public static synchronized MySQLBanMapper getInstance(AugmentedHardcore plugin) {
-        if (instance == null) {
-            instance = new MySQLBanMapper(plugin);
-        }
-        return instance;
-    }
-
-    private MySQLBanMapper(AugmentedHardcore plugin) {
+    public MySQLBanMapper(AugmentedHardcore plugin) {
         super(plugin);
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -17,17 +17,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
-    private static MySQLPlayerMapper instance;
+    private final MySQLBanMapper banMapper;
 
-    public static synchronized MySQLPlayerMapper getInstance(AugmentedHardcore plugin) {
-        if (instance == null) {
-            instance = new MySQLPlayerMapper(plugin);
-        }
-        return instance;
-    }
-
-    private MySQLPlayerMapper(AugmentedHardcore plugin) {
+    public MySQLPlayerMapper(AugmentedHardcore plugin) {
         super(plugin);
+        this.banMapper = new MySQLBanMapper(plugin);
     }
 
     @Override
@@ -75,7 +69,7 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
                             deathBans
                     );
                 }
-                Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance(this.plugin).getBanFromResultSetSync(resultSet);
+                Pair<Integer, Ban> banPair = this.banMapper.getBanFromResultSetSync(resultSet);
                 if (banPair != null) {
                     deathBans.put(banPair.getValue0(), banPair.getValue1());
                 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -24,6 +24,7 @@ import java.util.logging.Level;
 public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     private static MySQLServerMapper instance;
+    private final MySQLBanMapper banMapper;
 
     public static synchronized MySQLServerMapper getInstance(AugmentedHardcore plugin) {
         if (instance == null) {
@@ -34,6 +35,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     private MySQLServerMapper(AugmentedHardcore plugin) {
         super(plugin);
+        this.banMapper = new MySQLBanMapper(plugin);
     }
 
     @Override
@@ -67,7 +69,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                     totalDeathBans = resultSet.getInt("total_death_bans");
                     String uuidString = resultSet.getString("player_uuid");
                     if (uuidString != null && !uuidString.isEmpty()) {
-                        Pair<Integer, Ban> banPair = MySQLBanMapper.getInstance(this.plugin).getBanFromResultSetSync(resultSet);
+                        Pair<Integer, Ban> banPair = this.banMapper.getBanFromResultSetSync(resultSet);
                         if (banPair != null) {
                             deathBans.put(UUID.fromString(uuidString), banPair);
                         }
@@ -98,7 +100,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 this.plugin.getLogger().log(Level.SEVERE, "Could not update server data.", e);
                 return;
             }
-            data.getOngoingBans().forEach((key, value) -> MySQLBanMapper.getInstance(this.plugin).updateBan(this.plugin.getServer(), key, value.getBan()));
+            data.getOngoingBans().forEach((key, value) -> this.banMapper.updateBan(this.plugin.getServer(), key, value.getBan()));
         }, this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Could not update server data asynchronously.", ex);
             return null;
@@ -126,6 +128,6 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     @Override
     public void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban) {
-        MySQLBanMapper.getInstance(this.plugin).updateBan(null, uuid, ban);
+        this.banMapper.updateBan(null, uuid, ban);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -41,7 +41,7 @@ public class PlayerRepository {
 
     private void initializeMapper() {
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLPlayerMapper.getInstance(this.plugin);
+            this.mapper = new MySQLPlayerMapper(this.plugin);
         } else {
             this.mapper = new YAMLPlayerMapper(this.plugin);
         }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -33,6 +33,10 @@ public class ServerRepository {
         });
     }
 
+    public void onReload() {
+        this.initializeMapper();
+    }
+
     private void initializeMapper() {
         this.mapper = new YAMLServerMapper(this.plugin);
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {


### PR DESCRIPTION
## Summary
- remove singleton patterns from MySQLPlayerMapper and MySQLBanMapper
- instantiate mappers directly and rebuild instances on reload
- wire server mapper to use dedicated ban mapper instance

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b39f8645788327a4cce69310a0ef50