### PR TITLE
Add default case for command handling

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/commands/Commands.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/Commands.java
@@ -67,6 +67,8 @@ public class Commands implements TabCompleter {
             case "serverdeathbans":
                 new CommandServerDeathBans(cs, args).run();
                 break;
+            default:
+                return false;
         }
         return true;
     }


### PR DESCRIPTION
## Summary
- Ensure onCommand returns false for unknown commands so Bukkit can display usage

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b39f87918c8327807ff119aff2e344