### PR TITLE
Add null-safe item metadata utilities

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/utilities/InventoryUtils.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/InventoryUtils.java
@@ -11,6 +11,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import java.util.Collections;
 import java.util.List;
 
 public class InventoryUtils {
@@ -19,8 +20,14 @@ public class InventoryUtils {
         ItemMeta im = item.getItemMeta();
         if (im != null) {
             im.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-            im.setDisplayName(displayName);
-            im.setLore(lore);
+            if (displayName != null) {
+                im.setDisplayName(displayName);
+            }
+            if (lore != null) {
+                im.setLore(lore);
+            } else {
+                im.setLore(Collections.emptyList());
+            }
             if (glowing) {
                 im.addEnchant(Enchantment.INFINITY, 1, true);
                 im.addItemFlags(ItemFlag.HIDE_ENCHANTS);
@@ -35,8 +42,14 @@ public class InventoryUtils {
         SkullMeta sm = (SkullMeta) item.getItemMeta();
         if (sm != null) {
             sm.setOwningPlayer(player);
-            sm.setDisplayName(displayName);
-            sm.setLore(lore);
+            if (displayName != null) {
+                sm.setDisplayName(displayName);
+            }
+            if (lore != null) {
+                sm.setLore(lore);
+            } else {
+                sm.setLore(Collections.emptyList());
+            }
             item.setItemMeta(sm);
         }
         return item;
@@ -47,8 +60,14 @@ public class InventoryUtils {
         PotionMeta pm = (PotionMeta) item.getItemMeta();
         if (pm != null) {
             pm.addCustomEffect(new PotionEffect(PotionEffectType.SPEED, 3600, 1), true);
-            pm.setDisplayName(displayName);
-            pm.setLore(lore);
+            if (displayName != null) {
+                pm.setDisplayName(displayName);
+            }
+            if (lore != null) {
+                pm.setLore(lore);
+            } else {
+                pm.setLore(Collections.emptyList());
+            }
             item.setItemMeta(pm);
         }
         return item;


### PR DESCRIPTION
## Summary
- Avoid NullPointerExceptions when setting item display names and lore
- Default lore to an empty list when absent

## Testing
- `mvn -q test` *(fails: PluginResolutionException - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ad84e2f8832797751d9e681eff96