### PR TITLE
Add hashCode implementation for Killer domain class

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/Killer.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/Killer.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.EntityType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class Killer {
     private final String name;
@@ -71,5 +72,10 @@ public class Killer {
         if (o == null || getClass() != o.getClass()) return false;
         Killer killer = (Killer) o;
         return getName().equals(killer.getName()) && getType().equals(killer.getType());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name, this.type);
     }
 }


### PR DESCRIPTION
## Summary
- implement `hashCode` in `Killer` using `Objects.hash` for name and type

## Testing
- `mvn -q test` *(fails: PluginResolutionException: Could not transfer artifact maven-resources-plugin due to network being unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ad85119c8327a672fe7ca4be1823