### PR TITLE
Protect BanManager from external modification

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/data/BanManager.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/BanManager.java
@@ -3,6 +3,7 @@ package com.backtobedrock.augmentedhardcore.domain.data;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import org.javatuples.Pair;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.TreeMap;
@@ -23,7 +24,7 @@ public class BanManager {
     }
 
     public NavigableMap<Integer, Ban> getBans() {
-        return bans;
+        return Collections.unmodifiableNavigableMap(this.bans);
     }
 
     public int getBanCount() {
@@ -34,6 +35,10 @@ public class BanManager {
         int key = (bans.isEmpty() ? 0 : bans.lastKey()) + 1;
         bans.put(key, ban);
         return new Pair<>(key, ban);
+    }
+
+    public void clearBans() {
+        this.bans.clear();
     }
 
     public Ban getLastDeathBan() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -817,7 +817,7 @@ public class PlayerData {
         this.setTimeTillNextRevive(this.plugin.getConfigurations().getReviveConfiguration().isReviveOnFirstJoin() ? 0L : this.plugin.getConfigurations().getReviveConfiguration().getTimeBetweenRevives());
         this.setTimeTillNextLifePart(this.plugin.getConfigurations().getLivesAndLifePartsConfiguration().getPlaytimePerLifePart());
         this.setTimeTillNextMaxHealth(this.plugin.getConfigurations().getMaxHealthConfiguration().getPlaytimePerHalfHeart());
-        this.banManager.getBans().clear();
+        this.banManager.clearBans();
         this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> serverData.getBan(this.player.getUniqueId()).finish());
         this.plugin.getPlayerRepository().deletePlayerData(this.player);
         this.plugin.getPlayerRepository().updatePlayerData(this);


### PR DESCRIPTION
## Summary
- Return an unmodifiable view from `BanManager#getBans` to prevent external mutation
- Add `clearBans` helper and use it in `PlayerData#reset`

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ad85d1f08327a62be88cd9f5de84