### PR TITLE
Specify plugin executor for async tasks

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDeath.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerDeath.java
@@ -13,10 +13,12 @@ public class ListenerPlayerDeath extends AbstractEventListener {
     public void PlayerDeathListener(PlayerDeathEvent event) {
         Player player = event.getEntity();
 
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> playerData.onDeath(event, player)).exceptionally(ex -> {
-            this.plugin.getLogger().log(Level.SEVERE, "Error handling player death.", ex);
-            return null;
-        });
+        this.plugin.getPlayerRepository().getByPlayer(player)
+                .thenAcceptAsync(playerData -> playerData.onDeath(event, player), this.plugin.getExecutor())
+                .exceptionallyAsync(ex -> {
+                    this.plugin.getLogger().log(Level.SEVERE, "Error handling player death.", ex);
+                    return null;
+                }, this.plugin.getExecutor());
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerJoin.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerJoin.java
@@ -14,10 +14,12 @@ public class ListenerPlayerJoin extends AbstractEventListener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
 
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(e -> e.onJoin(player)).exceptionally(ex -> {
-            this.plugin.getLogger().log(Level.SEVERE, "Error handling player join.", ex);
-            return null;
-        });
+        this.plugin.getPlayerRepository().getByPlayer(player)
+                .thenAcceptAsync(e -> e.onJoin(player), this.plugin.getExecutor())
+                .exceptionallyAsync(ex -> {
+                    this.plugin.getLogger().log(Level.SEVERE, "Error handling player join.", ex);
+                    return null;
+                }, this.plugin.getExecutor());
 
         if (player.isOp() && this.plugin.getUpdateChecker().isOutdated()) {
             Bukkit.getScheduler().runTaskLaterAsynchronously(this.plugin, () -> player.sendMessage(String.format("§eA new version (§f%s§e) of §f%s§e is available on Spigot.org. Your current version is §f%s§e.", this.plugin.getUpdateChecker().getNewestVersion(), this.plugin.getDescription().getName(), this.plugin.getDescription().getVersion())), 5L);

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
@@ -19,14 +19,16 @@ public class GuiRevive extends AbstractConfirmationGui {
         super(String.format("Reviving %s", reviving.getName()));
         this.reviverData = reviverData;
         this.reviving = reviving;
-        this.plugin.getPlayerRepository().getByPlayer(this.reviving).thenAcceptAsync(playerData -> {
-            this.revivingData = playerData;
-            this.updateInfo(true);
-            this.updateConfirmation(true);
-        }).exceptionally(ex -> {
-            this.plugin.getLogger().log(Level.SEVERE, "Error loading revive GUI.", ex);
-            return null;
-        });
+        this.plugin.getPlayerRepository().getByPlayer(this.reviving)
+                .thenAcceptAsync(playerData -> {
+                    this.revivingData = playerData;
+                    this.updateInfo(true);
+                    this.updateConfirmation(true);
+                }, this.plugin.getExecutor())
+                .exceptionallyAsync(ex -> {
+                    this.plugin.getLogger().log(Level.SEVERE, "Error loading revive GUI.", ex);
+                    return null;
+                }, this.plugin.getExecutor());
         this.initialize();
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/runnables/Playtime/AbstractPlaytime.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/Playtime/AbstractPlaytime.java
@@ -32,18 +32,19 @@ public abstract class AbstractPlaytime extends BukkitRunnable {
 
     @Override
     public void run() {
-        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> {
-            if (serverData.isDeathBanned(this.player.getUniqueId())) {
-                return;
-            }
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer())
+                .thenAcceptAsync(serverData -> {
+                    if (serverData.isDeathBanned(this.player.getUniqueId())) {
+                        return;
+                    }
 
-            this.timerTask();
-            this.timer++;
-            if (this.timer == 300) {
-                this.plugin.getPlayerRepository().updatePlayerData(this.playerData);
-                this.timer = 0;
-            }
-        });
+                    this.timerTask();
+                    this.timer++;
+                    if (this.timer == 300) {
+                        this.plugin.getPlayerRepository().updatePlayerData(this.playerData);
+                        this.timer = 0;
+                    }
+                }, this.plugin.getExecutor());
     }
 
     protected abstract void timerTask();

--- a/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
@@ -37,7 +37,8 @@ public class Unban extends BukkitRunnable {
 
     public void finish() {
         this.stop();
-        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> serverData.removeBan(this.player));
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer())
+                .thenAcceptAsync(serverData -> serverData.removeBan(this.player), this.plugin.getExecutor());
     }
 
     @Override


### PR DESCRIPTION
## Summary
- ensure player event handlers and GUI loaders execute async callbacks using plugin executor
- route unban and playtime runnables through plugin thread pool for consistency

## Testing
- `mvn -q -e -DskipTests package` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ad8748d08327b14b9a0b1466ed51