### PR TITLE
Pass plugin instance to GUI constructors

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandDeathBans.java
@@ -48,7 +48,7 @@ public class CommandDeathBans extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiPlayerDeathBans(playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiPlayerDeathBans(this.plugin, playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing death bans command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandMyStats.java
@@ -48,7 +48,7 @@ public class CommandMyStats extends AbstractCommand {
     }
 
     private void runCommand(OfflinePlayer player) {
-        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiMyStats(this.sender, playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
+        this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> PlayerUtils.openInventory(this.sender, new GuiMyStats(this.plugin, this.sender, playerData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing my stats command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandRevive.java
@@ -38,7 +38,7 @@ public class CommandRevive extends AbstractCommand {
                     return;
                 }
 
-                AbstractGui gui = new GuiRevive(playerData, this.target);
+                AbstractGui gui = new GuiRevive(this.plugin, playerData, this.target);
                 PlayerUtils.openInventory(this.sender, gui);
             }, this.plugin.getExecutor()).exceptionally(ex -> {
                 this.plugin.getLogger().log(Level.SEVERE, "Error executing revive command.", ex);

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandServerDeathBans.java
@@ -28,7 +28,7 @@ public class CommandServerDeathBans extends AbstractCommand {
         }
 
 
-        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> PlayerUtils.openInventory(this.sender, new GuiServerDeathBans(this.sender, serverData)), this.plugin.getExecutor()).exceptionally(ex -> {
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(serverData -> PlayerUtils.openInventory(this.sender, new GuiServerDeathBans(this.plugin, this.sender, serverData)), this.plugin.getExecutor()).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Error executing server death bans command.", ex);
             return null;
         });

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractConfirmationGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractConfirmationGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.AbstractClickAction;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.ClickActionCloseInventory;
 
@@ -9,8 +10,8 @@ import java.util.List;
 
 public abstract class AbstractConfirmationGui extends AbstractGui {
 
-    public AbstractConfirmationGui(String title) {
-        super(new CustomHolder(54, title));
+    public AbstractConfirmationGui(AugmentedHardcore plugin, String title) {
+        super(plugin, new CustomHolder(54, title));
     }
 
     @Override
@@ -26,7 +27,7 @@ public abstract class AbstractConfirmationGui extends AbstractGui {
     }
 
     public void updateCancellation(boolean update) {
-        this.setIcon(38, new Icon(this.plugin.getConfigurations().getGuisConfiguration().getCancellationDisplay().getItem(), Collections.singletonList(new ClickActionCloseInventory())), update);
+        this.setIcon(38, new Icon(this.plugin.getConfigurations().getGuisConfiguration().getCancellationDisplay().getItem(), Collections.singletonList(new ClickActionCloseInventory(this.plugin))), update);
     }
 
     public void updateInfo(Icon icon, boolean update) {

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import org.bukkit.OfflinePlayer;
 import org.javatuples.Pair;
@@ -11,8 +12,8 @@ import java.util.logging.Level;
 public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
     protected final Map<Pair<OfflinePlayer, Integer>, Ban> bans = new LinkedHashMap<>();
 
-    public AbstractDeathBansGui(String title, int dataSize) {
-        super(new CustomHolder(dataSize, title), dataSize);
+    public AbstractDeathBansGui(AugmentedHardcore plugin, String title, int dataSize) {
+        super(plugin, new CustomHolder(dataSize, title), dataSize);
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractGui.java
@@ -2,7 +2,6 @@ package com.backtobedrock.augmentedhardcore.guis;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Collections;
 import java.util.List;
@@ -11,8 +10,8 @@ public abstract class AbstractGui {
     protected final AugmentedHardcore plugin;
     protected final CustomHolder customHolder;
 
-    public AbstractGui(CustomHolder customHolder) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public AbstractGui(AugmentedHardcore plugin, CustomHolder customHolder) {
+        this.plugin = plugin;
         this.customHolder = customHolder;
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractPaginatedGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractPaginatedGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.ClickActionNextPage;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.ClickActionPreviousPage;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
@@ -12,8 +13,8 @@ public abstract class AbstractPaginatedGui extends AbstractGui {
     protected int currentPage = 1;
     protected int totalPages;
 
-    public AbstractPaginatedGui(CustomHolder customHolder, int dataCount) {
-        super(customHolder);
+    public AbstractPaginatedGui(AugmentedHardcore plugin, CustomHolder customHolder, int dataCount) {
+        super(plugin, customHolder);
         this.totalPages = (int) Math.ceil((double) dataCount / 28);
     }
 
@@ -28,7 +29,7 @@ public abstract class AbstractPaginatedGui extends AbstractGui {
     protected void setData() {
         //Previous page button
         if (this.totalPages > 1 && this.currentPage > 1) {
-            this.customHolder.setIcon((this.customHolder.getRowAmount() - 1) * 9 + 3, new Icon(this.previousPageDisplayItem(), Collections.singletonList(new ClickActionPreviousPage(this))));
+            this.customHolder.setIcon((this.customHolder.getRowAmount() - 1) * 9 + 3, new Icon(this.previousPageDisplayItem(), Collections.singletonList(new ClickActionPreviousPage(this.plugin, this))));
         }
 
         //Current page
@@ -36,7 +37,7 @@ public abstract class AbstractPaginatedGui extends AbstractGui {
 
         //Next page button
         if (this.totalPages > 1 && this.currentPage < this.totalPages) {
-            this.customHolder.setIcon((this.customHolder.getRowAmount() - 1) * 9 + 5, new Icon(this.nextPageDisplayItem(), Collections.singletonList(new ClickActionNextPage(this))));
+            this.customHolder.setIcon((this.customHolder.getRowAmount() - 1) * 9 + 5, new Icon(this.nextPageDisplayItem(), Collections.singletonList(new ClickActionNextPage(this.plugin, this))));
         }
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/guis/CustomHolder.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/CustomHolder.java
@@ -1,20 +1,16 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
-import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class CustomHolder implements InventoryHolder {
-    private final AugmentedHardcore plugin;
-
     private final String title;
     private final int size;
     private final int rowAmount;
@@ -23,7 +19,6 @@ public class CustomHolder implements InventoryHolder {
     private Inventory inventory = null;
 
     public CustomHolder(int size, String title) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
         size = Math.max(1, size);
         this.title = title;
         this.size = Math.min((int) (Math.ceil((double) size / 7) * 9) + 18, 54);

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiMyStats.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiMyStats.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.Permission;
 import com.backtobedrock.augmentedhardcore.domain.enums.TimePattern;
@@ -20,8 +21,8 @@ public class GuiMyStats extends AbstractGui {
     private final Player sender;
     private final boolean isOther;
 
-    public GuiMyStats(Player sender, PlayerData playerData) {
-        super(new CustomHolder(54, String.format("%s Information", playerData.getPlayer().getName())));
+    public GuiMyStats(AugmentedHardcore plugin, Player sender, PlayerData playerData) {
+        super(plugin, new CustomHolder(54, String.format("%s Information", playerData.getPlayer().getName())));
         this.playerData = playerData;
         this.sender = sender;
         this.isOther = !sender.getUniqueId().toString().equals(this.playerData.getPlayer().getUniqueId().toString());
@@ -97,7 +98,7 @@ public class GuiMyStats extends AbstractGui {
             );
             icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getReviveOnCooldownDisplay().getItem(), placeholders), Collections.emptyList());
         } else {
-            icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getReviveDisplay().getItem(), Collections.singletonList(new ClickActionOpenPlayerSelectionAnvilGui()));
+            icon = new Icon(this.plugin.getConfigurations().getGuisConfiguration().getReviveDisplay().getItem(), Collections.singletonList(new ClickActionOpenPlayerSelectionAnvilGui(this.plugin)));
         }
 
         this.setIcon(22, icon, update);
@@ -132,7 +133,7 @@ public class GuiMyStats extends AbstractGui {
             Map<String, String> placeholders = Map.of(
                     "total_death_bans", Integer.toString(playerData.getBanCount())
             );
-            icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getPreviousBansDisplay().getItem(), placeholders), Collections.singletonList(new ClickActionOpenBansGui(this.playerData)));
+            icon = new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(this.plugin.getConfigurations().getGuisConfiguration().getPreviousBansDisplay().getItem(), placeholders), Collections.singletonList(new ClickActionOpenBansGui(this.plugin, this.playerData)));
         }
 
         this.setIcon(31, icon, update);

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiPlayerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiPlayerDeathBans.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.TimePattern;
@@ -19,8 +20,8 @@ import java.util.concurrent.TimeUnit;
 public class GuiPlayerDeathBans extends AbstractDeathBansGui {
     private final PlayerData playerData;
 
-    public GuiPlayerDeathBans(PlayerData playerData) {
-        super(String.format("%s Death Bans", playerData.getPlayer().getName()), playerData.getBanManager().getBanCount());
+    public GuiPlayerDeathBans(AugmentedHardcore plugin, PlayerData playerData) {
+        super(plugin, String.format("%s Death Bans", playerData.getPlayer().getName()), playerData.getBanManager().getBanCount());
         playerData.getBanManager().getBans().forEach((key, value) -> this.bans.put(new Pair<>(playerData.getPlayer(), key), value));
         this.playerData = playerData;
         this.initialize();

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiRevive.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.ClickActionConfirmRevive;
 import com.backtobedrock.augmentedhardcore.utilities.InventoryUtils;
@@ -15,8 +16,8 @@ public class GuiRevive extends AbstractConfirmationGui {
     private final OfflinePlayer reviving;
     private PlayerData revivingData;
 
-    public GuiRevive(PlayerData reviverData, OfflinePlayer reviving) {
-        super(String.format("Reviving %s", reviving.getName()));
+    public GuiRevive(AugmentedHardcore plugin, PlayerData reviverData, OfflinePlayer reviving) {
+        super(plugin, String.format("Reviving %s", reviving.getName()));
         this.reviverData = reviverData;
         this.reviving = reviving;
         this.plugin.getPlayerRepository().getByPlayer(this.reviving).thenAcceptAsync(playerData -> {
@@ -52,6 +53,6 @@ public class GuiRevive extends AbstractConfirmationGui {
     }
 
     public void updateConfirmation(boolean update) {
-        super.updateConfirmation(Collections.singletonList(new ClickActionConfirmRevive(this.reviverData, this.revivingData)), update);
+        super.updateConfirmation(Collections.singletonList(new ClickActionConfirmRevive(this.plugin, this.reviverData, this.revivingData)), update);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiServerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiServerDeathBans.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.Permission;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.AbstractClickAction;
@@ -18,8 +19,8 @@ public class GuiServerDeathBans extends AbstractDeathBansGui {
     private final ServerData serverData;
     private final Player player;
 
-    public GuiServerDeathBans(Player player, ServerData serverData) {
-        super("Currently Ongoing Death Bans", serverData.getTotalOngoingBans());
+    public GuiServerDeathBans(AugmentedHardcore plugin, Player player, ServerData serverData) {
+        super(plugin, "Currently Ongoing Death Bans", serverData.getTotalOngoingBans());
         serverData.getOngoingBans().forEach((key, value) -> this.bans.put(new Pair<>(Bukkit.getOfflinePlayer(key), value.getBan().getValue0()), value.getBan().getValue1()));
         this.serverData = serverData;
         this.player = player;
@@ -44,7 +45,7 @@ public class GuiServerDeathBans extends AbstractDeathBansGui {
         List<AbstractClickAction> clickActions = new ArrayList<>();
         ItemStack item = InventoryUtils.createPlayerSkull(String.format("%s - %s", player.getName(), this.plugin.getConfigurations().getGuisConfiguration().getBanDisplay().getName()), this.plugin.getConfigurations().getGuisConfiguration().getBanDisplay().getLore(), player);
         if (this.player.hasPermission(Permission.UNDEATHBAN.getPermissionString())) {
-            clickActions.add(new ClickActionOpenUnDeathBanGui(player, item));
+            clickActions.add(new ClickActionOpenUnDeathBanGui(this.plugin, player, item));
         }
         return new Icon(MessageUtils.replaceItemNameAndLorePlaceholders(item, placeholders), clickActions);
     }

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiUnDeathBan.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.clickActions.ClickActionConfirmUnDeathBan;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
@@ -10,8 +11,8 @@ public class GuiUnDeathBan extends AbstractConfirmationGui {
     private final OfflinePlayer target;
     private final ItemStack item;
 
-    public GuiUnDeathBan(OfflinePlayer target, ItemStack item) {
-        super(String.format("Undeathbanning %s", target.getName()));
+    public GuiUnDeathBan(AugmentedHardcore plugin, OfflinePlayer target, ItemStack item) {
+        super(plugin, String.format("Undeathbanning %s", target.getName()));
         this.target = target;
         this.item = item;
         this.initialize();
@@ -29,6 +30,6 @@ public class GuiUnDeathBan extends AbstractConfirmationGui {
     }
 
     public void updateConfirmation(boolean update) {
-        super.updateConfirmation(Collections.singletonList(new ClickActionConfirmUnDeathBan(this.target)), update);
+        super.updateConfirmation(Collections.singletonList(new ClickActionConfirmUnDeathBan(this.plugin, this.target)), update);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/AbstractClickAction.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/AbstractClickAction.java
@@ -2,14 +2,13 @@ package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public abstract class AbstractClickAction {
 
     protected final AugmentedHardcore plugin;
 
-    public AbstractClickAction() {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public AbstractClickAction(AugmentedHardcore plugin) {
+        this.plugin = plugin;
     }
 
     public abstract void execute(Player player);

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionCloseInventory.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionCloseInventory.java
@@ -1,8 +1,13 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.entity.Player;
 
 public class ClickActionCloseInventory extends AbstractClickAction {
+    public ClickActionCloseInventory(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
     @Override
     public void execute(Player player) {
         player.closeInventory();

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionConfirmRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionConfirmRevive.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import org.bukkit.entity.Player;
 
@@ -7,7 +8,8 @@ public class ClickActionConfirmRevive extends AbstractClickAction {
     private final PlayerData reviverData;
     private final PlayerData revivingData;
 
-    public ClickActionConfirmRevive(PlayerData reviverData, PlayerData revivingData) {
+    public ClickActionConfirmRevive(AugmentedHardcore plugin, PlayerData reviverData, PlayerData revivingData) {
+        super(plugin);
         this.reviverData = reviverData;
         this.revivingData = revivingData;
     }

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionConfirmUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionConfirmUnDeathBan.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.commands.CommandUnDeathBan;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -7,7 +8,8 @@ import org.bukkit.entity.Player;
 public class ClickActionConfirmUnDeathBan extends AbstractClickAction {
     private final OfflinePlayer target;
 
-    public ClickActionConfirmUnDeathBan(OfflinePlayer target) {
+    public ClickActionConfirmUnDeathBan(AugmentedHardcore plugin, OfflinePlayer target) {
+        super(plugin);
         this.target = target;
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionNextPage.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionNextPage.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.AbstractPaginatedGui;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -7,7 +8,8 @@ import org.bukkit.entity.Player;
 public class ClickActionNextPage extends AbstractClickAction {
     private final AbstractPaginatedGui paginatedGui;
 
-    public ClickActionNextPage(AbstractPaginatedGui paginatedGui) {
+    public ClickActionNextPage(AugmentedHardcore plugin, AbstractPaginatedGui paginatedGui) {
+        super(plugin);
         this.paginatedGui = paginatedGui;
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenBansGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenBansGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.guis.GuiPlayerDeathBans;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
@@ -9,12 +10,13 @@ public class ClickActionOpenBansGui extends AbstractClickAction {
 
     private final PlayerData playerData;
 
-    public ClickActionOpenBansGui(PlayerData playerData) {
+    public ClickActionOpenBansGui(AugmentedHardcore plugin, PlayerData playerData) {
+        super(plugin);
         this.playerData = playerData;
     }
 
     @Override
     public void execute(Player player) {
-        PlayerUtils.openInventory(player, new GuiPlayerDeathBans(this.playerData));
+        PlayerUtils.openInventory(player, new GuiPlayerDeathBans(this.plugin, this.playerData));
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenPlayerSelectionAnvilGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenPlayerSelectionAnvilGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.commands.CommandRevive;
 import net.wesjd.anvilgui.AnvilGUI;
 import org.bukkit.entity.Player;
@@ -7,6 +8,10 @@ import org.bukkit.entity.Player;
 import java.util.Collections;
 
 public class ClickActionOpenPlayerSelectionAnvilGui extends AbstractClickAction {
+    public ClickActionOpenPlayerSelectionAnvilGui(AugmentedHardcore plugin) {
+        super(plugin);
+    }
+
     @Override
     public void execute(Player player) {
         new AnvilGUI.Builder()

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenUnDeathBanGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionOpenUnDeathBanGui.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.GuiUnDeathBan;
 import com.backtobedrock.augmentedhardcore.utilities.PlayerUtils;
 import org.bukkit.OfflinePlayer;
@@ -10,13 +11,14 @@ public class ClickActionOpenUnDeathBanGui extends AbstractClickAction {
     private final OfflinePlayer target;
     private final ItemStack item;
 
-    public ClickActionOpenUnDeathBanGui(OfflinePlayer target, ItemStack item) {
+    public ClickActionOpenUnDeathBanGui(AugmentedHardcore plugin, OfflinePlayer target, ItemStack item) {
+        super(plugin);
         this.target = target;
         this.item = item;
     }
 
     @Override
     public void execute(Player player) {
-        PlayerUtils.openInventory(player, new GuiUnDeathBan(this.target, this.item));
+        PlayerUtils.openInventory(player, new GuiUnDeathBan(this.plugin, this.target, this.item));
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionPreviousPage.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/clickActions/ClickActionPreviousPage.java
@@ -1,5 +1,6 @@
 package com.backtobedrock.augmentedhardcore.guis.clickActions;
 
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.guis.AbstractPaginatedGui;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -7,7 +8,8 @@ import org.bukkit.entity.Player;
 public class ClickActionPreviousPage extends AbstractClickAction {
     private final AbstractPaginatedGui paginatedGui;
 
-    public ClickActionPreviousPage(AbstractPaginatedGui paginatedGui) {
+    public ClickActionPreviousPage(AugmentedHardcore plugin, AbstractPaginatedGui paginatedGui) {
+        super(plugin);
         this.paginatedGui = paginatedGui;
     }
 


### PR DESCRIPTION
## Summary
- refactor `AbstractGui` to receive `AugmentedHardcore` plugin instance
- update all GUI and click-action subclasses to pass the plugin and avoid `JavaPlugin.getPlugin`
- adjust command handlers to use the new constructors

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1 from/to maven-central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ad88981883278a38fac85445994d