### PR TITLE
Persist server data and wait for async tasks on shutdown

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -35,6 +35,7 @@ import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -101,7 +102,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         if (this.getServerRepository() != null) {
             ServerData serverData = this.getServerRepository().getServerDataSync();
             if (serverData != null) {
-                this.getServerRepository().updateServerData(serverData);
+                this.getServerRepository().updateServerData(serverData).join();
             }
         }
 
@@ -111,6 +112,13 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
         if (this.executor != null) {
             this.executor.shutdown();
+            try {
+                if (!this.executor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    this.getLogger().log(Level.WARNING, "Executor did not terminate in the allotted time.");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
 
         if (this.getConfigurations() != null && this.getConfigurations().getDataConfiguration().getDatabase() != null) {

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/IServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/IServerMapper.java
@@ -18,7 +18,7 @@ public interface IServerMapper {
     CompletableFuture<ServerData> getServerData(Server server);
 
     //Update
-    void updateServerData(ServerData data);
+    CompletableFuture<Void> updateServerData(ServerData data);
 
     //Delete
     void deleteServerData();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -40,7 +40,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     @Override
     public void insertServerDataAsync(ServerData serverData) {
-        CompletableFuture.runAsync(() -> this.updateServerData(serverData), this.plugin.getExecutor()).exceptionally(ex -> {
+        this.updateServerData(serverData).exceptionally(ex -> {
             this.plugin.getLogger().log(Level.SEVERE, "Could not insert server data asynchronously.", ex);
             return null;
         });
@@ -48,7 +48,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
     @Override
     public void insertServerDataSync(ServerData serverData) {
-        Bukkit.getScheduler().runTask(this.plugin, () -> this.updateServerData(serverData));
+        Bukkit.getScheduler().runTask(this.plugin, () -> this.updateServerData(serverData).join());
     }
 
     @Override
@@ -84,8 +84,8 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
     }
 
     @Override
-    public void updateServerData(ServerData data) {
-        CompletableFuture.runAsync(() -> {
+    public CompletableFuture<Void> updateServerData(ServerData data) {
+        return CompletableFuture.runAsync(() -> {
             String sql = "INSERT INTO ah_server (`server_ip`, `server_port`, `total_death_bans`)"
                     + "VALUES(?, ?, ?)"
                     + "ON DUPLICATE KEY UPDATE `total_death_bans` = ?;";

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -47,12 +47,15 @@ public class YAMLServerMapper implements IServerMapper {
     }
 
     @Override
-    public void updateServerData(ServerData data) {
+    public CompletableFuture<Void> updateServerData(ServerData data) {
         if (this.plugin.isStopping()) {
             this.insertServerDataSync(data);
-        } else {
-            this.insertServerDataAsync(data);
+            return CompletableFuture.completedFuture(null);
         }
+        return CompletableFuture.runAsync(() -> this.insertServerData(data), this.plugin.getExecutor()).exceptionally(ex -> {
+            this.plugin.getLogger().log(Level.SEVERE, "Could not insert server data.", ex);
+            return null;
+        });
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -72,8 +72,8 @@ public class ServerRepository {
         return this.serverData;
     }
 
-    public void updateServerData(ServerData data) {
-        this.mapper.updateServerData(data);
+    public CompletableFuture<Void> updateServerData(ServerData data) {
+        return this.mapper.updateServerData(data);
     }
 
     public void removeBanFromServerData(UUID uuid, Pair<Integer, Ban> banPair) {


### PR DESCRIPTION
## Summary
- Save server data synchronously during shutdown
- Wait for executor tasks to finish and log when they don't
- Return `CompletableFuture` from server data mappers

## Testing
- `mvn -q -e test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b814b808832788defd575eb56736