### PR TITLE
refactor: remove MySQLServerMapper singleton

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -23,17 +23,9 @@ import java.util.logging.Level;
 
 public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
 
-    private static MySQLServerMapper instance;
     private final MySQLBanMapper banMapper;
 
-    public static synchronized MySQLServerMapper getInstance(AugmentedHardcore plugin) {
-        if (instance == null) {
-            instance = new MySQLServerMapper(plugin);
-        }
-        return instance;
-    }
-
-    private MySQLServerMapper(AugmentedHardcore plugin) {
+    public MySQLServerMapper(AugmentedHardcore plugin) {
         super(plugin);
         this.banMapper = new MySQLBanMapper(plugin);
     }

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -38,9 +38,8 @@ public class ServerRepository {
     }
 
     private void initializeMapper() {
-        this.mapper = new YAMLServerMapper(this.plugin);
         if (this.plugin.getConfigurations().getDataConfiguration().getStorageType() == StorageType.MYSQL) {
-            this.mapper = MySQLServerMapper.getInstance(this.plugin);
+            this.mapper = new MySQLServerMapper(this.plugin);
         } else {
             this.mapper = new YAMLServerMapper(this.plugin);
         }


### PR DESCRIPTION
## Summary
- remove singleton pattern from MySQLServerMapper
- construct MySQLServerMapper directly in ServerRepository

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b81e900c8327b3ad46517d44f086