### PR TITLE
Replace javatuples Pair with BanEntry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,6 @@
             <version>1.10.2-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.javatuples</groupId>
-            <artifactId>javatuples</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.sirblobman.combatlogx</groupId>
             <artifactId>api</artifactId>
             <version>11.4-SNAPSHOT</version>

--- a/src/com/backtobedrock/augmentedhardcore/domain/BanEntry.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/BanEntry.java
@@ -1,0 +1,7 @@
+package com.backtobedrock.augmentedhardcore.domain;
+
+/**
+ * Simple record representing a ban entry consisting of the ban's id and the {@link Ban} itself.
+ */
+public record BanEntry(int id, Ban ban) {
+}

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/BanManager.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/BanManager.java
@@ -1,7 +1,7 @@
 package com.backtobedrock.augmentedhardcore.domain.data;
 
 import com.backtobedrock.augmentedhardcore.domain.Ban;
-import org.javatuples.Pair;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 
 import java.util.Collections;
 import java.util.Map;
@@ -31,10 +31,10 @@ public class BanManager {
         return bans.size();
     }
 
-    public Pair<Integer, Ban> addBan(Ban ban) {
+    public BanEntry addBan(Ban ban) {
         int key = (bans.isEmpty() ? 0 : bans.lastKey()) + 1;
         bans.put(key, ban);
-        return new Pair<>(key, ban);
+        return new BanEntry(key, ban);
     }
 
     public void clearBans() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -2,6 +2,7 @@ package com.backtobedrock.augmentedhardcore.domain.data;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.Killer;
 import com.backtobedrock.augmentedhardcore.domain.enums.DamageCause;
 import com.backtobedrock.augmentedhardcore.domain.enums.Permission;
@@ -23,7 +24,6 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.javatuples.Pair;
 
 import java.time.LocalDateTime;
 import java.util.*;
@@ -342,10 +342,10 @@ public class PlayerData {
         });
     }
 
-    private Pair<Integer, Ban> addBan(Ban ban) {
-        Pair<Integer, Ban> pair = this.banManager.addBan(ban);
+    private BanEntry addBan(Ban ban) {
+        BanEntry entry = this.banManager.addBan(ban);
         this.observers.forEach((k, value) -> value.get(MyStatsDeathBansObserver.class).update());
-        return pair;
+        return entry;
     }
 
     public void onRespawn(Player player) {

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerGameModeChange.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerGameModeChange.java
@@ -24,7 +24,7 @@ public class ListenerPlayerGameModeChange extends AbstractEventListener {
         Unban ban = this.plugin.getServerRepository().getServerDataSync().getBan(player.getUniqueId());
 
         if (ban != null && event.getNewGameMode() != GameMode.SPECTATOR) {
-            player.sendMessage(String.format("§cCannot change game mode, you are still banned for another %s.", MessageUtils.getTimeFromTicks(MessageUtils.timeUnitToTicks(ChronoUnit.SECONDS.between(LocalDateTime.now(), ban.getBan().getValue1().getExpirationDate()), TimeUnit.SECONDS), TimePattern.LONG)));
+            player.sendMessage(String.format("§cCannot change game mode, you are still banned for another %s.", MessageUtils.getTimeFromTicks(MessageUtils.timeUnitToTicks(ChronoUnit.SECONDS.between(LocalDateTime.now(), ban.getBan().ban().getExpirationDate()), TimeUnit.SECONDS), TimePattern.LONG));
             event.setCancelled(true);
         }
     }

--- a/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerLogin.java
+++ b/src/com/backtobedrock/augmentedhardcore/eventListeners/ListenerPlayerLogin.java
@@ -25,7 +25,7 @@ public class ListenerPlayerLogin extends AbstractEventListener {
                 return;
             }
         } else {
-            ban = unban.getBan().getValue1();
+            ban = unban.getBan().ban();
         }
 
         if (player.hasPermission(Permission.BYPASS_BAN_SPECTATOR.getPermissionString())) {

--- a/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/AbstractDeathBansGui.java
@@ -3,14 +3,13 @@ package com.backtobedrock.augmentedhardcore.guis;
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import org.bukkit.OfflinePlayer;
-import org.javatuples.Pair;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 
 public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
-    protected final Map<Pair<OfflinePlayer, Integer>, Ban> bans = new LinkedHashMap<>();
+    protected final Map<Map.Entry<OfflinePlayer, Integer>, Ban> bans = new LinkedHashMap<>();
 
     public AbstractDeathBansGui(AugmentedHardcore plugin, String title, int dataSize) {
         super(plugin, new CustomHolder(dataSize, title), dataSize);
@@ -29,7 +28,7 @@ public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
         super.setData();
 
         List<Icon> icons = new ArrayList<>();
-        List<Map.Entry<Pair<OfflinePlayer, Integer>, Ban>> currentData = new ArrayList<>(this.bans.entrySet()).subList((this.currentPage - 1) * 28, Math.min(this.currentPage * 28, this.bans.size()));
+        List<Map.Entry<Map.Entry<OfflinePlayer, Integer>, Ban>> currentData = new ArrayList<>(this.bans.entrySet()).subList((this.currentPage - 1) * 28, Math.min(this.currentPage * 28, this.bans.size()));
 
         //loading icons
         for (int i = 0; i < currentData.size(); i++) {
@@ -49,9 +48,9 @@ public abstract class AbstractDeathBansGui extends AbstractPaginatedGui {
         Map<String, String> placeholders = new HashMap<>();
         CompletableFuture.runAsync(() -> {
             currentData.forEach(e -> {
-                placeholders.put("ban_number", e.getKey().getValue1().toString());
+                placeholders.put("ban_number", e.getKey().getValue().toString());
                 placeholders.putAll(e.getValue().getPlaceholdersReplacements());
-                icons.add(this.getIcon(e.getKey().getValue0(), placeholders));
+                icons.add(this.getIcon(e.getKey().getKey(), placeholders));
                 if (icons.size() == 7) {
                     this.customHolder.addRow(icons);
                     icons.clear();

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiPlayerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiPlayerDeathBans.java
@@ -8,7 +8,6 @@ import com.backtobedrock.augmentedhardcore.utilities.InventoryUtils;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.Statistic;
-import org.javatuples.Pair;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -22,7 +21,7 @@ public class GuiPlayerDeathBans extends AbstractDeathBansGui {
 
     public GuiPlayerDeathBans(AugmentedHardcore plugin, PlayerData playerData) {
         super(plugin, String.format("%s Death Bans", playerData.getPlayer().getName()), playerData.getBanManager().getBanCount());
-        playerData.getBanManager().getBans().forEach((key, value) -> this.bans.put(new Pair<>(playerData.getPlayer(), key), value));
+        playerData.getBanManager().getBans().forEach((key, value) -> this.bans.put(Map.entry(playerData.getPlayer(), key), value));
         this.playerData = playerData;
         this.initialize();
     }

--- a/src/com/backtobedrock/augmentedhardcore/guis/GuiServerDeathBans.java
+++ b/src/com/backtobedrock/augmentedhardcore/guis/GuiServerDeathBans.java
@@ -11,7 +11,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.javatuples.Pair;
 
 import java.util.*;
 
@@ -21,7 +20,7 @@ public class GuiServerDeathBans extends AbstractDeathBansGui {
 
     public GuiServerDeathBans(AugmentedHardcore plugin, Player player, ServerData serverData) {
         super(plugin, "Currently Ongoing Death Bans", serverData.getTotalOngoingBans());
-        serverData.getOngoingBans().forEach((key, value) -> this.bans.put(new Pair<>(Bukkit.getOfflinePlayer(key), value.getBan().getValue0()), value.getBan().getValue1()));
+        serverData.getOngoingBans().forEach((key, value) -> this.bans.put(Map.entry(Bukkit.getOfflinePlayer(key), value.getBan().id()), value.getBan().ban()));
         this.serverData = serverData;
         this.player = player;
         this.initialize();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/IBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/IBanMapper.java
@@ -1,15 +1,14 @@
 package com.backtobedrock.augmentedhardcore.mappers.ban;
 
-import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import org.bukkit.Server;
-import org.javatuples.Pair;
 
 import java.util.UUID;
 
 public interface IBanMapper {
-    void insertBan(Server server, UUID uuid, Pair<Integer, Ban> ban);
+    void insertBan(Server server, UUID uuid, BanEntry ban);
 
-    void updateBan(Server server, UUID uuid, Pair<Integer, Ban> ban);
+    void updateBan(Server server, UUID uuid, BanEntry ban);
 
     void deleteBan(UUID uuid, Integer id);
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -2,12 +2,12 @@ package com.backtobedrock.augmentedhardcore.mappers.ban;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.Killer;
 import com.backtobedrock.augmentedhardcore.domain.Location;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
 import com.backtobedrock.augmentedhardcore.utilities.ConfigUtils;
 import org.bukkit.Server;
-import org.javatuples.Pair;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -21,10 +21,10 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
         super(plugin);
     }
 
-    public Pair<Integer, Ban> getBanFromResultSetSync(ResultSet resultSet) {
+    public BanEntry getBanFromResultSetSync(ResultSet resultSet) {
         try {
             if (resultSet.getObject("ban_id") != null) {
-                return new Pair<>(resultSet.getInt("ban_id"),
+                return new BanEntry(resultSet.getInt("ban_id"),
                         new Ban(
                                 resultSet.getTimestamp("start_date").toLocalDateTime(),
                                 resultSet.getTimestamp("expiration_date").toLocalDateTime(),
@@ -47,12 +47,12 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
     }
 
     @Override
-    public void insertBan(Server server, UUID uuid, Pair<Integer, Ban> ban) {
+    public void insertBan(Server server, UUID uuid, BanEntry ban) {
         this.updateBan(server, uuid, ban);
     }
 
     @Override
-    public void updateBan(Server server, UUID uuid, Pair<Integer, Ban> ban) {
+    public void updateBan(Server server, UUID uuid, BanEntry ban) {
         CompletableFuture.runAsync(() -> {
             String sql = "INSERT INTO ah_ban (`ban_id`,`player_uuid`,`server_ip`,`server_port`,`start_date`,`expiration_date`,`ban_time`,`damage_cause`,`damage_cause_type`,`world`,`x`,`y`,`z`,`has_killer`,`killer_name`,`killer_display_name`,`killer_entity_type`,`in_combat`,`in_combat_with_name`,`in_combat_with_display_name`,`in_combat_with_entity_type`,`death_message`,`time_since_previous_death_ban`,`time_since_previous_death`)"
                     + "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
@@ -93,34 +93,34 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
         });
     }
 
-    private void bindBanParameters(PreparedStatement preparedStatement, int startIndex, Server server, UUID uuid, Pair<Integer, Ban> ban) throws SQLException, UnknownHostException {
+    private void bindBanParameters(PreparedStatement preparedStatement, int startIndex, Server server, UUID uuid, BanEntry ban) throws SQLException, UnknownHostException {
         int index = startIndex;
         if (startIndex == 1) {
-            preparedStatement.setInt(index++, ban.getValue0());
+            preparedStatement.setInt(index++, ban.id());
             preparedStatement.setString(index++, uuid.toString());
         }
         preparedStatement.setString(index++, server != null ? InetAddress.getLocalHost().getHostAddress() : null);
         preparedStatement.setObject(index++, server != null ? this.plugin.getServer().getPort() : null);
-        preparedStatement.setTimestamp(index++, Timestamp.valueOf(ban.getValue1().getStartDate()));
-        preparedStatement.setTimestamp(index++, Timestamp.valueOf(ban.getValue1().getExpirationDate()));
-        preparedStatement.setInt(index++, ban.getValue1().getBanTime());
-        preparedStatement.setString(index++, ban.getValue1().getDamageCause().name());
-        preparedStatement.setString(index++, ban.getValue1().getDamageCauseType().name());
-        preparedStatement.setString(index++, ban.getValue1().getLocation().getWorld());
-        preparedStatement.setDouble(index++, ban.getValue1().getLocation().getX());
-        preparedStatement.setDouble(index++, ban.getValue1().getLocation().getY());
-        preparedStatement.setDouble(index++, ban.getValue1().getLocation().getZ());
-        preparedStatement.setBoolean(index++, ban.getValue1().getKiller() != null);
-        preparedStatement.setString(index++, ban.getValue1().getKiller() == null ? null : ban.getValue1().getKiller().getName());
-        preparedStatement.setString(index++, ban.getValue1().getKiller() == null ? null : ban.getValue1().getKiller().getDisplayName());
-        preparedStatement.setString(index++, ban.getValue1().getKiller() == null ? null : ban.getValue1().getKiller().getType().name());
-        preparedStatement.setBoolean(index++, ban.getValue1().getInCombatWith() != null);
-        preparedStatement.setString(index++, ban.getValue1().getInCombatWith() == null ? null : ban.getValue1().getInCombatWith().getName());
-        preparedStatement.setString(index++, ban.getValue1().getInCombatWith() == null ? null : ban.getValue1().getInCombatWith().getDisplayName());
-        preparedStatement.setString(index++, ban.getValue1().getInCombatWith() == null ? null : ban.getValue1().getInCombatWith().getType().name());
-        preparedStatement.setString(index++, ban.getValue1().getDeathMessage());
-        preparedStatement.setLong(index++, ban.getValue1().getTimeSincePreviousDeathBan());
-        preparedStatement.setLong(index, ban.getValue1().getTimeSincePreviousDeath());
+        preparedStatement.setTimestamp(index++, Timestamp.valueOf(ban.ban().getStartDate()));
+        preparedStatement.setTimestamp(index++, Timestamp.valueOf(ban.ban().getExpirationDate()));
+        preparedStatement.setInt(index++, ban.ban().getBanTime());
+        preparedStatement.setString(index++, ban.ban().getDamageCause().name());
+        preparedStatement.setString(index++, ban.ban().getDamageCauseType().name());
+        preparedStatement.setString(index++, ban.ban().getLocation().getWorld());
+        preparedStatement.setDouble(index++, ban.ban().getLocation().getX());
+        preparedStatement.setDouble(index++, ban.ban().getLocation().getY());
+        preparedStatement.setDouble(index++, ban.ban().getLocation().getZ());
+        preparedStatement.setBoolean(index++, ban.ban().getKiller() != null);
+        preparedStatement.setString(index++, ban.ban().getKiller() == null ? null : ban.ban().getKiller().getName());
+        preparedStatement.setString(index++, ban.ban().getKiller() == null ? null : ban.ban().getKiller().getDisplayName());
+        preparedStatement.setString(index++, ban.ban().getKiller() == null ? null : ban.ban().getKiller().getType().name());
+        preparedStatement.setBoolean(index++, ban.ban().getInCombatWith() != null);
+        preparedStatement.setString(index++, ban.ban().getInCombatWith() == null ? null : ban.ban().getInCombatWith().getName());
+        preparedStatement.setString(index++, ban.ban().getInCombatWith() == null ? null : ban.ban().getInCombatWith().getDisplayName());
+        preparedStatement.setString(index++, ban.ban().getInCombatWith() == null ? null : ban.ban().getInCombatWith().getType().name());
+        preparedStatement.setString(index++, ban.ban().getDeathMessage());
+        preparedStatement.setLong(index++, ban.ban().getTimeSincePreviousDeathBan());
+        preparedStatement.setLong(index, ban.ban().getTimeSincePreviousDeath());
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/player/MySQLPlayerMapper.java
@@ -2,12 +2,12 @@ package com.backtobedrock.augmentedhardcore.mappers.player;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.data.PlayerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
 import com.backtobedrock.augmentedhardcore.mappers.ban.MySQLBanMapper;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.javatuples.Pair;
 
 import java.sql.*;
 import java.time.LocalDateTime;
@@ -69,9 +69,9 @@ public class MySQLPlayerMapper extends AbstractMapper implements IPlayerMapper {
                             deathBans
                     );
                 }
-                Pair<Integer, Ban> banPair = this.banMapper.getBanFromResultSetSync(resultSet);
+                BanEntry banPair = this.banMapper.getBanFromResultSetSync(resultSet);
                 if (banPair != null) {
-                    deathBans.put(banPair.getValue0(), banPair.getValue1());
+                    deathBans.put(banPair.id(), banPair.ban());
                 }
             }
             return playerData;

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/IServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/IServerMapper.java
@@ -1,9 +1,8 @@
 package com.backtobedrock.augmentedhardcore.mappers.server;
 
-import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import org.bukkit.Server;
-import org.javatuples.Pair;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -23,5 +22,5 @@ public interface IServerMapper {
     //Delete
     void deleteServerData();
 
-    void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban);
+    void deleteBanFromServerData(UUID uuid, BanEntry ban);
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -1,13 +1,12 @@
 package com.backtobedrock.augmentedhardcore.mappers.server;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
-import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.mappers.AbstractMapper;
 import com.backtobedrock.augmentedhardcore.mappers.ban.MySQLBanMapper;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
-import org.javatuples.Pair;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -63,13 +62,13 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                 preparedStatement.setString(1, InetAddress.getLocalHost().getHostAddress());
                 preparedStatement.setInt(2, server.getPort());
                 ResultSet resultSet = preparedStatement.executeQuery();
-                Map<UUID, Pair<Integer, Ban>> deathBans = new HashMap<>();
+                Map<UUID, BanEntry> deathBans = new HashMap<>();
                 int totalDeathBans = 0;
                 while (resultSet.next()) {
                     totalDeathBans = resultSet.getInt("total_death_bans");
                     String uuidString = resultSet.getString("player_uuid");
                     if (uuidString != null && !uuidString.isEmpty()) {
-                        Pair<Integer, Ban> banPair = this.banMapper.getBanFromResultSetSync(resultSet);
+                        BanEntry banPair = this.banMapper.getBanFromResultSetSync(resultSet);
                         if (banPair != null) {
                             deathBans.put(UUID.fromString(uuidString), banPair);
                         }
@@ -127,7 +126,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
     }
 
     @Override
-    public void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban) {
+    public void deleteBanFromServerData(UUID uuid, BanEntry ban) {
         this.banMapper.updateBan(null, uuid, ban);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -1,13 +1,12 @@
 package com.backtobedrock.augmentedhardcore.mappers.server;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
-import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.javatuples.Pair;
 
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +69,7 @@ public class YAMLServerMapper implements IServerMapper {
     }
 
     @Override
-    public void deleteBanFromServerData(UUID uuid, Pair<Integer, Ban> ban) {
+    public void deleteBanFromServerData(UUID uuid, BanEntry ban) {
         CompletableFuture.runAsync(() -> {
             FileConfiguration config = this.getConfig();
             config.set("OngoingBans." + uuid, null);

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -1,14 +1,13 @@
 package com.backtobedrock.augmentedhardcore.repositories;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
-import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
 import com.backtobedrock.augmentedhardcore.domain.enums.StorageType;
 import com.backtobedrock.augmentedhardcore.mappers.server.IServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.MySQLServerMapper;
 import com.backtobedrock.augmentedhardcore.mappers.server.YAMLServerMapper;
 import org.bukkit.Server;
-import org.javatuples.Pair;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -76,7 +75,7 @@ public class ServerRepository {
         this.mapper.updateServerData(data);
     }
 
-    public void removeBanFromServerData(UUID uuid, Pair<Integer, Ban> banPair) {
+    public void removeBanFromServerData(UUID uuid, BanEntry banPair) {
         this.mapper.deleteBanFromServerData(uuid, banPair);
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
@@ -2,11 +2,11 @@ package com.backtobedrock.augmentedhardcore.runnables;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
+import com.backtobedrock.augmentedhardcore.domain.BanEntry;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.javatuples.Pair;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -15,16 +15,16 @@ import java.util.concurrent.TimeUnit;
 public class Unban extends BukkitRunnable {
     private final AugmentedHardcore plugin;
     private final OfflinePlayer player;
-    private final Pair<Integer, Ban> ban;
+    private final BanEntry ban;
 
-    public Unban(OfflinePlayer player, Pair<Integer, Ban> ban) {
+    public Unban(OfflinePlayer player, BanEntry ban) {
         this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
         this.player = player;
         this.ban = ban;
     }
 
     public void start() {
-        this.runTaskLaterAsynchronously(this.plugin, MessageUtils.timeUnitToTicks(ChronoUnit.SECONDS.between(LocalDateTime.now(), this.ban.getValue1().getExpirationDate()), TimeUnit.SECONDS));
+        this.runTaskLaterAsynchronously(this.plugin, MessageUtils.timeUnitToTicks(ChronoUnit.SECONDS.between(LocalDateTime.now(), this.ban.ban().getExpirationDate()), TimeUnit.SECONDS));
     }
 
     private void stop() {
@@ -46,7 +46,7 @@ public class Unban extends BukkitRunnable {
         this.finish();
     }
 
-    public Pair<Integer, Ban> getBan() {
+    public BanEntry getBan() {
         return ban;
     }
 }

--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -8,7 +8,6 @@ description: A very customizable and lightweight plugin that enhances the hardco
 api-version: 1.13
 softdepend: [ PlaceholderAPI, CombatLogX ]
 libraries:
-  - org.javatuples:javatuples:1.2
   - com.zaxxer:HikariCP:4.0.3
 commands:
   augmentedhardcore:


### PR DESCRIPTION
## Summary
- introduce `BanEntry` record to encapsulate ban id and data
- refactor bans to use `BanEntry` instead of javatuples `Pair`
- drop javatuples dependency from build and plugin configuration

## Testing
- `mvn -q -e -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b820913c83278d98292f869c3f35