### PR TITLE
Refactor time calculations using constants

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
             </plugin>
         </plugins>
     </build>
-    <dependencies>
+      <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
@@ -124,11 +124,17 @@
             <artifactId>ConfigUpdater</artifactId>
             <version>2.1-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>7.0.2</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-</project>
+          <dependency>
+              <groupId>com.zaxxer</groupId>
+              <artifactId>HikariCP</artifactId>
+              <version>7.0.2</version>
+              <scope>provided</scope>
+          </dependency>
+          <dependency>
+              <groupId>org.junit.jupiter</groupId>
+              <artifactId>junit-jupiter</artifactId>
+              <version>5.10.2</version>
+              <scope>test</scope>
+          </dependency>
+      </dependencies>
+  </project>

--- a/src/com/backtobedrock/augmentedhardcore/utilities/MessageUtils.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/MessageUtils.java
@@ -18,18 +18,30 @@ public class MessageUtils {
     public static final DateTimeFormatter MEDIUM_FORMATTER = DateTimeFormatter.ofPattern("MMM dd yyyy',' HH:mm z").withZone(ZoneId.systemDefault());
     public static final DateTimeFormatter LONG_FORMATTER = DateTimeFormatter.ofPattern("EEEE MMM dd yyyy 'at' HH:mm:ss z").withZone(ZoneId.systemDefault());
 
+    // Time constants
+    public static final long TICKS_PER_SECOND = 20L;
+    public static final long SECONDS_PER_MINUTE = 60L;
+    public static final long MINUTES_PER_HOUR = 60L;
+    public static final long HOURS_PER_DAY = 24L;
+    public static final long TICKS_PER_MINUTE = TICKS_PER_SECOND * SECONDS_PER_MINUTE;
+    public static final long TICKS_PER_HOUR = TICKS_PER_MINUTE * MINUTES_PER_HOUR;
+    public static final long TICKS_PER_DAY = TICKS_PER_HOUR * HOURS_PER_DAY;
+
     public static long timeUnitToTicks(long time, TimeUnit unit) {
-        return unit.toSeconds(time) * 20;
+        return unit.toSeconds(time) * TICKS_PER_SECOND;
     }
 
     public static long timeBetweenDatesToTicks(LocalDateTime date1, LocalDateTime date2) {
-        return Math.abs(ChronoUnit.SECONDS.between(date1, date2)) * 20;
+        return Math.abs(ChronoUnit.SECONDS.between(date1, date2)) * TICKS_PER_SECOND;
     }
 
     public static String getTimeFromTicks(long amount, TimePattern pattern) {
         StringBuilder sb = new StringBuilder();
 
-        long d = amount / 1728000, h = amount % 1728000 / 72000, m = amount % 72000 / 1200, s = amount % 1200 / 20;
+        long d = amount / TICKS_PER_DAY;
+        long h = amount % TICKS_PER_DAY / TICKS_PER_HOUR;
+        long m = amount % TICKS_PER_HOUR / TICKS_PER_MINUTE;
+        long s = amount % TICKS_PER_MINUTE / TICKS_PER_SECOND;
 
         switch (pattern) {
             case LONG:

--- a/src/test/java/com/backtobedrock/augmentedhardcore/utilities/MessageUtilsTest.java
+++ b/src/test/java/com/backtobedrock/augmentedhardcore/utilities/MessageUtilsTest.java
@@ -1,0 +1,43 @@
+package com.backtobedrock.augmentedhardcore.utilities;
+
+import com.backtobedrock.augmentedhardcore.domain.enums.TimePattern;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link MessageUtils#getTimeFromTicks(long, TimePattern)} to ensure
+ * the various {@link TimePattern} formats handle edge cases correctly.
+ */
+public class MessageUtilsTest {
+
+    @Test
+    void testGetTimeFromTicksZero() {
+        assertEquals("", MessageUtils.getTimeFromTicks(0, TimePattern.LONG));
+        assertEquals("", MessageUtils.getTimeFromTicks(0, TimePattern.SHORT));
+        assertEquals("00:00:00:00", MessageUtils.getTimeFromTicks(0, TimePattern.DIGITAL));
+    }
+
+    @Test
+    void testGetTimeFromTicksMixedValues() {
+        long ticks = MessageUtils.TICKS_PER_DAY
+                + 2 * MessageUtils.TICKS_PER_HOUR
+                + 3 * MessageUtils.TICKS_PER_MINUTE
+                + 4 * MessageUtils.TICKS_PER_SECOND;
+
+        assertEquals("1 day, 2 hours, 3 minutes, 4 seconds",
+                MessageUtils.getTimeFromTicks(ticks, TimePattern.LONG));
+        assertEquals("1d, 2h, 3m, 4s",
+                MessageUtils.getTimeFromTicks(ticks, TimePattern.SHORT));
+        assertEquals("01:02:03:04",
+                MessageUtils.getTimeFromTicks(ticks, TimePattern.DIGITAL));
+    }
+
+    @Test
+    void testDigitalPadding() {
+        long ticks = 3 * MessageUtils.TICKS_PER_MINUTE + 5 * MessageUtils.TICKS_PER_SECOND;
+        assertEquals("00:00:03:05",
+                MessageUtils.getTimeFromTicks(ticks, TimePattern.DIGITAL));
+    }
+}
+


### PR DESCRIPTION
## Summary
- define reusable constants for tick and time units
- refactor getTimeFromTicks to use constants
- add JUnit tests for long, short, and digital formatting edge cases

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 or one of its dependencies could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3b8204694832790ef2fa862640339