### PR TITLE
refactor: inject plugin into constructors

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -78,7 +78,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         this.initialize();
 
         //update checker
-        this.updateChecker = new UpdateChecker();
+        this.updateChecker = new UpdateChecker(this);
         this.updateChecker.start();
 
         //bstats metrics

--- a/src/com/backtobedrock/augmentedhardcore/domain/Ban.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/Ban.java
@@ -8,7 +8,6 @@ import com.backtobedrock.augmentedhardcore.domain.enums.TimePattern;
 import com.backtobedrock.augmentedhardcore.utilities.ConfigUtils;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.plugin.java.JavaPlugin;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -32,8 +31,8 @@ public class Ban {
     private final long timeSincePreviousDeath;
     private LocalDateTime expirationDate;
 
-    public Ban(LocalDateTime startDate, LocalDateTime expirationDate, int banTime, DamageCause damageCause, DamageCauseType damageCauseType, Location location, Killer killer, Killer inCombatWith, String deathMessage, long timeSincePreviousDeathBan, long timeSincePreviousDeath) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public Ban(AugmentedHardcore plugin, LocalDateTime startDate, LocalDateTime expirationDate, int banTime, DamageCause damageCause, DamageCauseType damageCauseType, Location location, Killer killer, Killer inCombatWith, String deathMessage, long timeSincePreviousDeathBan, long timeSincePreviousDeath) {
+        this.plugin = plugin;
         this.startDate = startDate;
         this.expirationDate = expirationDate;
         this.banTime = banTime;
@@ -47,7 +46,7 @@ public class Ban {
         this.timeSincePreviousDeath = timeSincePreviousDeath;
     }
 
-    public static Ban Deserialize(ConfigurationSection section) {
+    public static Ban Deserialize(AugmentedHardcore plugin, ConfigurationSection section) {
         LocalDateTime cStartDate = LocalDateTime.parse(section.getString("StartDate", LocalDateTime.MIN.toString()));
         LocalDateTime cExpirationDate = LocalDateTime.parse(section.getString("ExpirationDate", LocalDateTime.MIN.toString()));
         DamageCause cDamageCause = ConfigUtils.getDamageCause(section.getString("DamageCause", DamageCause.VOID.name()), DamageCause.VOID);
@@ -76,7 +75,7 @@ public class Ban {
             cInCombatWith = Killer.Deserialize(inCombatWithSection);
         }
 
-        return new Ban(cStartDate, cExpirationDate, cBanTime, cDamageCause, cDamageCauseType, cLocation, cKiller, cInCombatWith, cDeathMessage, cTimeSincePreviousDeathBan, cTimeSincePreviousDeath);
+        return new Ban(plugin, cStartDate, cExpirationDate, cBanTime, cDamageCause, cDamageCauseType, cLocation, cKiller, cInCombatWith, cDeathMessage, cTimeSincePreviousDeathBan, cTimeSincePreviousDeath);
     }
 
     public String getBanMessage() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -94,7 +94,7 @@ public class PlayerData {
             for (String e : bansSection.getKeys(false)) {
                 ConfigurationSection banSection = bansSection.getConfigurationSection(e);
                 if (banSection != null) {
-                    cBans.put(Integer.parseInt(e), Ban.Deserialize(banSection));
+                    cBans.put(Integer.parseInt(e), Ban.Deserialize(plugin, banSection));
                 }
             }
         }

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
@@ -7,7 +7,6 @@ import com.backtobedrock.augmentedhardcore.runnables.Unban;
 import org.bukkit.*;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.javatuples.Pair;
 
 import java.time.LocalDateTime;
@@ -25,12 +24,12 @@ public class ServerData {
     private final Map<String, Ban> ongoingIPBans = new HashMap<>();
     private int totalDeathBans;
 
-    public ServerData() {
-        this(0, new HashMap<>());
+    public ServerData(AugmentedHardcore plugin) {
+        this(plugin, 0, new HashMap<>());
     }
 
-    public ServerData(int totalDeathBans, Map<UUID, Pair<Integer, Ban>> ongoingBans) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public ServerData(AugmentedHardcore plugin, int totalDeathBans, Map<UUID, Pair<Integer, Ban>> ongoingBans) {
+        this.plugin = plugin;
         this.server = this.plugin.getServer();
         this.totalDeathBans = totalDeathBans;
         ongoingBans.forEach((key, value) -> {
@@ -42,7 +41,7 @@ public class ServerData {
         });
     }
 
-    public static ServerData deserialize(ConfigurationSection section) {
+    public static ServerData deserialize(AugmentedHardcore plugin, ConfigurationSection section) {
         Map<UUID, Pair<Integer, Ban>> cOngoingBans = new HashMap<>();
         int cTotalBans = section.getInt("TotalDeathBans", section.getInt("TotalBans", 0));
 
@@ -61,7 +60,7 @@ public class ServerData {
                             ConfigurationSection banConfiguration = banSection.getConfigurationSection(a);
                             Ban ban = null;
                             if (banConfiguration != null) {
-                                ban = Ban.Deserialize(banConfiguration);
+                                ban = Ban.Deserialize(plugin, banConfiguration);
                             }
                             //if exists, put in map
                             if (ban != null) {
@@ -74,7 +73,7 @@ public class ServerData {
                 }
             });
         }
-        return new ServerData(cTotalBans, cOngoingBans);
+        return new ServerData(plugin, cTotalBans, cOngoingBans);
     }
 
     public int getTotalDeathBans() {
@@ -102,7 +101,7 @@ public class ServerData {
     }
 
     private void startBan(OfflinePlayer player, Pair<Integer, Ban> ban) {
-        Unban unban = new Unban(player, ban);
+        Unban unban = new Unban(this.plugin, player, ban);
         this.ongoingBans.put(player.getUniqueId(), unban);
         if (ban.getValue1().getBanTime() != -1) {
             unban.start();

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -26,6 +26,7 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
             if (resultSet.getObject("ban_id") != null) {
                 return new Pair<>(resultSet.getInt("ban_id"),
                         new Ban(
+                                this.plugin,
                                 resultSet.getTimestamp("start_date").toLocalDateTime(),
                                 resultSet.getTimestamp("expiration_date").toLocalDateTime(),
                                 resultSet.getInt("ban_time"),

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/MySQLServerMapper.java
@@ -75,7 +75,7 @@ public class MySQLServerMapper extends AbstractMapper implements IServerMapper {
                         }
                     }
                 }
-                return new ServerData(totalDeathBans, deathBans);
+                return new ServerData(this.plugin, totalDeathBans, deathBans);
             } catch (SQLException | UnknownHostException e) {
                 this.plugin.getLogger().log(Level.SEVERE, "Could not load server data.", e);
             }

--- a/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/server/YAMLServerMapper.java
@@ -43,7 +43,7 @@ public class YAMLServerMapper implements IServerMapper {
 
     @Override
     public CompletableFuture<ServerData> getServerData(Server server) {
-        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(getConfig()), this.plugin.getExecutor());
+        return CompletableFuture.supplyAsync(() -> ServerData.deserialize(this.plugin, getConfig()), this.plugin.getExecutor());
     }
 
     @Override

--- a/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/PlayerRepository.java
@@ -70,7 +70,7 @@ public class PlayerRepository {
         }
 
         if (!player.isOnline()) {
-            new ClearCache(player).runTaskLater(this.plugin, 6000);
+            new ClearCache(this.plugin, player).runTaskLater(this.plugin, 6000);
         }
 
         return playerData;

--- a/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
+++ b/src/com/backtobedrock/augmentedhardcore/repositories/ServerRepository.java
@@ -61,7 +61,7 @@ public class ServerRepository {
 
     private ServerData getFromDataAndCache(ServerData serverData) {
         if (serverData == null) {
-            serverData = new ServerData();
+            serverData = new ServerData(this.plugin);
             this.mapper.insertServerDataAsync(serverData);
         }
         this.serverData = serverData;

--- a/src/com/backtobedrock/augmentedhardcore/runnables/ClearCache.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/ClearCache.java
@@ -2,7 +2,6 @@ package com.backtobedrock.augmentedhardcore.runnables;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 public class ClearCache extends BukkitRunnable {
@@ -10,8 +9,8 @@ public class ClearCache extends BukkitRunnable {
     private final AugmentedHardcore plugin;
     private final OfflinePlayer player;
 
-    public ClearCache(OfflinePlayer player) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public ClearCache(AugmentedHardcore plugin, OfflinePlayer player) {
+        this.plugin = plugin;
         this.player = player;
     }
 

--- a/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/Unban.java
@@ -4,7 +4,6 @@ import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import com.backtobedrock.augmentedhardcore.domain.Ban;
 import com.backtobedrock.augmentedhardcore.utilities.MessageUtils;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.javatuples.Pair;
 
@@ -17,8 +16,8 @@ public class Unban extends BukkitRunnable {
     private final OfflinePlayer player;
     private final Pair<Integer, Ban> ban;
 
-    public Unban(OfflinePlayer player, Pair<Integer, Ban> ban) {
-        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    public Unban(AugmentedHardcore plugin, OfflinePlayer player, Pair<Integer, Ban> ban) {
+        this.plugin = plugin;
         this.player = player;
         this.ban = ban;
     }

--- a/src/com/backtobedrock/augmentedhardcore/runnables/UpdateChecker.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/UpdateChecker.java
@@ -1,7 +1,6 @@
 package com.backtobedrock.augmentedhardcore.runnables;
 
 import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import java.io.IOException;
@@ -14,9 +13,13 @@ import java.util.logging.Level;
 
 public class UpdateChecker extends BukkitRunnable {
 
-    private final AugmentedHardcore plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+    private final AugmentedHardcore plugin;
     private boolean outdated = false;
     private String newestVersion;
+
+    public UpdateChecker(AugmentedHardcore plugin) {
+        this.plugin = plugin;
+    }
 
     public void start() {
         this.runTaskTimerAsynchronously(this.plugin, 0L, 12000L);

--- a/src/com/backtobedrock/augmentedhardcore/utilities/EventUtils.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/EventUtils.java
@@ -151,6 +151,7 @@ public class EventUtils {
                 timeSinceLastDeath = MessageUtils.timeBetweenDatesToTicks(now, playerData.getLastDeath());
 
         return new Ban(
+                JavaPlugin.getPlugin(AugmentedHardcore.class),
                 now,
                 now.plusMinutes(banTime),
                 banTime,


### PR DESCRIPTION
## Summary
- pass AugmentedHardcore plugin into Ban, ServerData, Unban, ClearCache and UpdateChecker constructors
- remove static plugin lookups and forward plugin instance through call sites

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:pom:3.3.1: Network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_b_68b3b821f3748327a4311b1f8b7756a6