### PR TITLE
Add configurable global revive/undeathban reset schedule

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -13,6 +13,7 @@ import com.backtobedrock.augmentedhardcore.mappers.Patch;
 import com.backtobedrock.augmentedhardcore.mappers.player.patches.LastDeathAdditionPatch;
 import com.backtobedrock.augmentedhardcore.repositories.PlayerRepository;
 import com.backtobedrock.augmentedhardcore.repositories.ServerRepository;
+import com.backtobedrock.augmentedhardcore.runnables.GlobalReviveUnDeathBan;
 import com.backtobedrock.augmentedhardcore.runnables.UpdateChecker;
 import com.backtobedrock.augmentedhardcore.utilities.Metrics;
 import com.backtobedrock.augmentedhardcore.utilities.placeholderAPI.PlaceholdersAugmentedHardcore;
@@ -58,6 +59,7 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     //runnables
     private UpdateChecker updateChecker;
+    private GlobalReviveUnDeathBan globalReviveUnDeathBan;
 
     //async executor
     private ExecutorService executor;
@@ -81,6 +83,8 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         //update checker
         this.updateChecker = new UpdateChecker();
         this.updateChecker.start();
+        this.globalReviveUnDeathBan = new GlobalReviveUnDeathBan();
+        this.globalReviveUnDeathBan.start();
 
         //bstats metrics
         Metrics metrics = new Metrics(this, 10843);
@@ -108,6 +112,9 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
         if (this.updateChecker != null) {
             this.updateChecker.stop();
+        }
+        if (this.globalReviveUnDeathBan != null) {
+            this.globalReviveUnDeathBan.stop();
         }
 
         if (this.executor != null) {
@@ -317,6 +324,10 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
 
     public UpdateChecker getUpdateChecker() {
         return updateChecker;
+    }
+
+    public GlobalReviveUnDeathBan getGlobalReviveUnDeathBan() {
+        return globalReviveUnDeathBan;
     }
 
     public ExecutorService getExecutor() {

--- a/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/commands/CommandNextRevive.java
@@ -57,7 +57,7 @@ public class CommandNextRevive extends AbstractCommand {
     }
 
     private void sendSuccessMessage(PlayerData playerData) {
-        long reviveCooldown = playerData.getPlaytimeTracker().getTimeTillNextRevive();
+        long reviveCooldown = playerData.getTimeTillNextRevive();
         this.cs.sendMessage(this.plugin.getMessages().getCommandNextRevive(this.cs instanceof Player && ((Player) this.cs).getUniqueId().toString().equals(playerData.getPlayer().getUniqueId().toString())
                 ? "You"
                 : playerData.getPlayer().getName(), MessageUtils.getTimeFromTicks(reviveCooldown, TimePattern.LONG)));

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
@@ -1,10 +1,18 @@
 package com.backtobedrock.augmentedhardcore.domain.configurationDomain;
 
 import com.backtobedrock.augmentedhardcore.utilities.ConfigUtils;
+import com.backtobedrock.augmentedhardcore.domain.configurationDomain.configurationHelperClasses.GlobalReviveUnDeathBanConfiguration;
+import com.backtobedrock.augmentedhardcore.domain.enums.GlobalResetScheduleType;
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.plugin.java.JavaPlugin;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.OptionalInt;
+import java.util.logging.Level;
 
 public class ConfigurationRevive {
     private final boolean useRevive;
@@ -13,14 +21,16 @@ public class ConfigurationRevive {
     private final int timeBetweenRevives;
     private final boolean reviveOnFirstJoin;
     private final List<String> disableReviveInWorlds;
+    private final GlobalReviveUnDeathBanConfiguration globalReviveUnDeathBanConfiguration;
 
-    public ConfigurationRevive(boolean useRevive, int livesLostOnReviving, int livesGainedOnRevive, int timeBetweenRevives, boolean reviveOnFirstJoin, List<String> disableReviveInWorlds) {
+    public ConfigurationRevive(boolean useRevive, int livesLostOnReviving, int livesGainedOnRevive, int timeBetweenRevives, boolean reviveOnFirstJoin, List<String> disableReviveInWorlds, GlobalReviveUnDeathBanConfiguration globalReviveUnDeathBanConfiguration) {
         this.useRevive = useRevive;
         this.livesLostOnReviving = livesLostOnReviving;
         this.livesGainedOnRevive = livesGainedOnRevive;
         this.timeBetweenRevives = timeBetweenRevives;
         this.reviveOnFirstJoin = reviveOnFirstJoin;
         this.disableReviveInWorlds = disableReviveInWorlds;
+        this.globalReviveUnDeathBanConfiguration = globalReviveUnDeathBanConfiguration;
     }
 
     public static ConfigurationRevive deserialize(ConfigurationSection section) {
@@ -30,6 +40,7 @@ public class ConfigurationRevive {
         OptionalInt cTimeBetweenRevives = ConfigUtils.checkMinMax("TimeBetweenRevives", section.getInt("TimeBetweenRevives", 1440), 0, Integer.MAX_VALUE);
         boolean cReviveOnFirstJoin = section.getBoolean("ReviveOnFirstJoin", false);
         List<String> cDisableReviveInWorlds = section.getStringList("DisableReviveInWorlds").stream().map(String::toLowerCase).toList();
+        GlobalReviveUnDeathBanConfiguration cGlobalReviveUnDeathBanConfiguration = deserializeGlobalReviveUnDeathBan(section.getConfigurationSection("GlobalReviveUnDeathBan"));
 
         if (cTimeBetweenRevives.isEmpty() || cLivesLostOnReviving.isEmpty() || cLivesGainedOnRevive.isEmpty()) {
             return null;
@@ -41,8 +52,55 @@ public class ConfigurationRevive {
                 cLivesGainedOnRevive.getAsInt(),
                 cTimeBetweenRevives.getAsInt() * 1200,
                 cReviveOnFirstJoin,
-                cDisableReviveInWorlds
+                cDisableReviveInWorlds,
+                cGlobalReviveUnDeathBanConfiguration
         );
+    }
+
+    private static GlobalReviveUnDeathBanConfiguration deserializeGlobalReviveUnDeathBan(ConfigurationSection section) {
+        if (section == null) {
+            return new GlobalReviveUnDeathBanConfiguration(false, GlobalResetScheduleType.DAILY, 24, LocalTime.MIDNIGHT, DayOfWeek.MONDAY, 1, ZoneId.of("UTC"));
+        }
+
+        boolean enabled = section.getBoolean("Enabled", false);
+
+        GlobalResetScheduleType scheduleType;
+        try {
+            scheduleType = GlobalResetScheduleType.valueOf(section.getString("ScheduleType", "DAILY").toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.ScheduleType value. Defaulting to DAILY.");
+            scheduleType = GlobalResetScheduleType.DAILY;
+        }
+
+        int intervalHours = Math.max(1, section.getInt("IntervalHours", 24));
+
+        LocalTime timeOfDay;
+        try {
+            timeOfDay = LocalTime.parse(section.getString("TimeOfDay", "00:00"));
+        } catch (Exception ex) {
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.TimeOfDay value. Expected HH:mm, defaulting to 00:00.");
+            timeOfDay = LocalTime.MIDNIGHT;
+        }
+
+        DayOfWeek dayOfWeek;
+        try {
+            dayOfWeek = DayOfWeek.valueOf(section.getString("DayOfWeek", "MONDAY").toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.DayOfWeek value. Defaulting to MONDAY.");
+            dayOfWeek = DayOfWeek.MONDAY;
+        }
+
+        int dayOfMonth = Math.max(1, Math.min(31, section.getInt("DayOfMonth", 1)));
+
+        ZoneId timezone;
+        try {
+            timezone = ZoneId.of(section.getString("Timezone", "UTC"));
+        } catch (Exception ex) {
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.Timezone value. Defaulting to UTC.");
+            timezone = ZoneId.of("UTC");
+        }
+
+        return new GlobalReviveUnDeathBanConfiguration(enabled, scheduleType, intervalHours, timeOfDay, dayOfWeek, dayOfMonth, timezone);
     }
 
     public boolean isUseRevive() {
@@ -67,5 +125,9 @@ public class ConfigurationRevive {
 
     public int getLivesGainedOnRevive() {
         return livesGainedOnRevive;
+    }
+
+    public GlobalReviveUnDeathBanConfiguration getGlobalReviveUnDeathBanConfiguration() {
+        return globalReviveUnDeathBanConfiguration;
     }
 }

--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/GlobalReviveUnDeathBanConfiguration.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/configurationHelperClasses/GlobalReviveUnDeathBanConfiguration.java
@@ -1,0 +1,55 @@
+package com.backtobedrock.augmentedhardcore.domain.configurationDomain.configurationHelperClasses;
+
+import com.backtobedrock.augmentedhardcore.domain.enums.GlobalResetScheduleType;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+public class GlobalReviveUnDeathBanConfiguration {
+    private final boolean enabled;
+    private final GlobalResetScheduleType scheduleType;
+    private final int intervalHours;
+    private final LocalTime timeOfDay;
+    private final DayOfWeek dayOfWeek;
+    private final int dayOfMonth;
+    private final ZoneId timezone;
+
+    public GlobalReviveUnDeathBanConfiguration(boolean enabled, GlobalResetScheduleType scheduleType, int intervalHours, LocalTime timeOfDay, DayOfWeek dayOfWeek, int dayOfMonth, ZoneId timezone) {
+        this.enabled = enabled;
+        this.scheduleType = scheduleType;
+        this.intervalHours = intervalHours;
+        this.timeOfDay = timeOfDay;
+        this.dayOfWeek = dayOfWeek;
+        this.dayOfMonth = dayOfMonth;
+        this.timezone = timezone;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public GlobalResetScheduleType getScheduleType() {
+        return scheduleType;
+    }
+
+    public int getIntervalHours() {
+        return intervalHours;
+    }
+
+    public LocalTime getTimeOfDay() {
+        return timeOfDay;
+    }
+
+    public DayOfWeek getDayOfWeek() {
+        return dayOfWeek;
+    }
+
+    public int getDayOfMonth() {
+        return dayOfMonth;
+    }
+
+    public ZoneId getTimezone() {
+        return timezone;
+    }
+}

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -107,6 +107,9 @@ public class PlayerData {
     }
 
     public long getTimeTillNextRevive() {
+        if (this.plugin.getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration().isEnabled()) {
+            return this.plugin.getGlobalReviveUnDeathBan().getTicksUntilNextRun();
+        }
         return this.playtimeTracker.getTimeTillNextRevive();
     }
 
@@ -545,7 +548,9 @@ public class PlayerData {
         }
 
         if (this.plugin.getConfigurations().getReviveConfiguration().isUseRevive() && this.plugin.getConfigurations().getReviveConfiguration().getTimeBetweenRevives() > 0 && !this.isSpectatorBanned() && !player.hasPermission(Permission.BYPASS_REVIVECOOLDOWN.getPermissionString())) {
-            this.playtime.add(new PlaytimeRevive(this, player));
+            if (!this.plugin.getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration().isEnabled()) {
+                this.playtime.add(new PlaytimeRevive(this, player));
+            }
         }
 
         this.playtime.forEach(AbstractPlaytime::start);
@@ -648,7 +653,9 @@ public class PlayerData {
             }
             revivingData.onRevive(reviverPlayer);
 
-            this.setTimeTillNextRevive(this.plugin.getConfigurations().getReviveConfiguration().getTimeBetweenRevives());
+            if (!this.plugin.getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration().isEnabled()) {
+                this.setTimeTillNextRevive(this.plugin.getConfigurations().getReviveConfiguration().getTimeBetweenRevives());
+            }
 
             int amount = this.plugin.getConfigurations().getReviveConfiguration().getLivesLostOnReviving();
             this.decreaseLives(amount);
@@ -742,6 +749,10 @@ public class PlayerData {
 
     public void onReload(Player player) {
         this.onJoin(player);
+    }
+
+    public void resetReviveCooldown() {
+        this.setTimeTillNextRevive(0L);
     }
 
     public Map<String, Object> serialize() {

--- a/src/com/backtobedrock/augmentedhardcore/domain/enums/GlobalResetScheduleType.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/enums/GlobalResetScheduleType.java
@@ -1,0 +1,8 @@
+package com.backtobedrock.augmentedhardcore.domain.enums;
+
+public enum GlobalResetScheduleType {
+    DAILY,
+    WEEKLY,
+    MONTHLY,
+    INTERVAL_HOURS
+}

--- a/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
@@ -1,0 +1,113 @@
+package com.backtobedrock.augmentedhardcore.runnables;
+
+import com.backtobedrock.augmentedhardcore.AugmentedHardcore;
+import com.backtobedrock.augmentedhardcore.domain.configurationDomain.configurationHelperClasses.GlobalReviveUnDeathBanConfiguration;
+import com.backtobedrock.augmentedhardcore.domain.data.ServerData;
+import com.backtobedrock.augmentedhardcore.domain.enums.GlobalResetScheduleType;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+
+public class GlobalReviveUnDeathBan extends BukkitRunnable {
+    private final AugmentedHardcore plugin;
+    private final GlobalReviveUnDeathBanConfiguration configuration;
+    private ZonedDateTime nextRunAt;
+    private BukkitTask task;
+
+    public GlobalReviveUnDeathBan() {
+        this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
+        this.configuration = this.plugin.getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration();
+        this.nextRunAt = computeNextRun(ZonedDateTime.now(this.configuration.getTimezone()));
+    }
+
+    public void start() {
+        if (!this.configuration.isEnabled()) {
+            return;
+        }
+        this.task = this.runTaskTimerAsynchronously(this.plugin, 1200L, 1200L);
+    }
+
+    public void stop() {
+        if (this.task != null) {
+            this.task.cancel();
+            this.task = null;
+        }
+    }
+
+    public long getTicksUntilNextRun() {
+        if (!this.configuration.isEnabled()) {
+            return 0L;
+        }
+        long seconds = Math.max(0L, java.time.Duration.between(ZonedDateTime.now(this.configuration.getTimezone()), this.nextRunAt).getSeconds());
+        return seconds * 20L;
+    }
+
+    @Override
+    public void run() {
+        if (!this.configuration.isEnabled()) {
+            return;
+        }
+
+        ZonedDateTime now = ZonedDateTime.now(this.configuration.getTimezone());
+        if (now.isBefore(this.nextRunAt)) {
+            return;
+        }
+
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(this::runGlobalReset, this.plugin.getExecutor());
+        this.nextRunAt = computeNextRun(now.plusSeconds(1));
+    }
+
+    private void runGlobalReset(ServerData serverData) {
+        new ArrayList<>(serverData.getOngoingBans().keySet()).forEach(serverData::unDeathBan);
+
+        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+            this.plugin.getPlayerRepository().getByPlayer(onlinePlayer).thenAcceptAsync(playerData -> {
+                if (playerData != null) {
+                    playerData.resetReviveCooldown();
+                    this.plugin.getPlayerRepository().updatePlayerData(playerData);
+                }
+            }, this.plugin.getExecutor());
+        }
+    }
+
+    private ZonedDateTime computeNextRun(ZonedDateTime now) {
+        ZoneId zone = this.configuration.getTimezone();
+        GlobalResetScheduleType scheduleType = this.configuration.getScheduleType();
+        return switch (scheduleType) {
+            case DAILY -> {
+                ZonedDateTime candidate = now.with(this.configuration.getTimeOfDay());
+                if (!candidate.isAfter(now)) {
+                    candidate = candidate.plusDays(1);
+                }
+                yield candidate;
+            }
+            case WEEKLY -> {
+                ZonedDateTime candidate = now.with(TemporalAdjusters.nextOrSame(this.configuration.getDayOfWeek())).with(this.configuration.getTimeOfDay());
+                if (!candidate.isAfter(now)) {
+                    candidate = candidate.with(TemporalAdjusters.next(this.configuration.getDayOfWeek())).with(this.configuration.getTimeOfDay());
+                }
+                yield candidate;
+            }
+            case MONTHLY -> {
+                int day = Math.min(this.configuration.getDayOfMonth(), YearMonth.from(LocalDateTime.now(zone)).lengthOfMonth());
+                ZonedDateTime candidate = now.withDayOfMonth(day).with(this.configuration.getTimeOfDay());
+                if (!candidate.isAfter(now)) {
+                    ZonedDateTime nextMonth = now.plusMonths(1);
+                    int nextDay = Math.min(this.configuration.getDayOfMonth(), YearMonth.from(nextMonth).lengthOfMonth());
+                    candidate = nextMonth.withDayOfMonth(nextDay).with(this.configuration.getTimeOfDay());
+                }
+                yield candidate;
+            }
+            case INTERVAL_HOURS -> now.plusHours(this.configuration.getIntervalHours());
+        };
+    }
+}

--- a/src/com/backtobedrock/augmentedhardcore/utilities/placeholderAPI/PlaceholdersAugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/utilities/placeholderAPI/PlaceholdersAugmentedHardcore.java
@@ -50,19 +50,19 @@ public class PlaceholdersAugmentedHardcore extends PlaceholderExpansion {
                     case "time_till_next_life_part_short":
                         return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextLifePart(), TimePattern.SHORT);
                     case "time_till_next_revive_short":
-                        return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextRevive(), TimePattern.SHORT);
+                        return MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.SHORT);
                     case "time_till_next_max_health_long":
                         return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextMaxHealth(), TimePattern.LONG);
                     case "time_till_next_life_part_long":
                         return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextLifePart(), TimePattern.LONG);
                     case "time_till_next_revive_long":
-                        return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextRevive(), TimePattern.LONG);
+                        return MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.LONG);
                     case "time_till_next_max_health_digital":
                         return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextMaxHealth(), TimePattern.DIGITAL);
                     case "time_till_next_life_part_digital":
                         return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextLifePart(), TimePattern.DIGITAL);
                     case "time_till_next_revive_digital":
-                        return MessageUtils.getTimeFromTicks(playerData.getPlaytimeTracker().getTimeTillNextRevive(), TimePattern.DIGITAL);
+                        return MessageUtils.getTimeFromTicks(playerData.getTimeTillNextRevive(), TimePattern.DIGITAL);
                     case "life_parts":
                         return Integer.toString(playerData.getLifeManager().getLifeParts());
                     case "lives":

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -560,6 +560,28 @@ DisableReviveInWorlds: [ ]
 #- world_nether
 #- world_the_end
 
+#Run a global schedule that resets revive cooldowns for everyone and removes all active death-bans.
+GlobalReviveUnDeathBan:
+  Enabled: false
+
+  #Options: DAILY / WEEKLY / MONTHLY / INTERVAL_HOURS
+  ScheduleType: "DAILY"
+
+  #Only used by INTERVAL_HOURS.
+  IntervalHours: 24
+
+  #Used by DAILY / WEEKLY / MONTHLY. 24h format (HH:mm).
+  TimeOfDay: "00:00"
+
+  #Only used by WEEKLY.
+  DayOfWeek: "MONDAY"
+
+  #Only used by MONTHLY.
+  DayOfMonth: 1
+
+  #Timezone used for this schedule (examples: UTC, America/New_York, Europe/Amsterdam).
+  Timezone: "UTC"
+
 
 ############################################################
 # +------------------------------------------------------+ #


### PR DESCRIPTION
### Motivation
- Provide a server-wide, scheduleable way to reset revive cooldowns and automatically undeathban players (daily/weekly/monthly or fixed-hour intervals) and allow using a configured timezone for the schedule.

### Description
- Added a new `GlobalReviveUnDeathBan` configuration block in `src/resources/config.yml` with `ScheduleType` (`DAILY`,`WEEKLY`,`MONTHLY`,`INTERVAL_HOURS`), `IntervalHours`, `TimeOfDay`, `DayOfWeek`, `DayOfMonth` and `Timezone` options.
- Introduced `GlobalResetScheduleType` and `GlobalReviveUnDeathBanConfiguration` domain classes and extended `ConfigurationRevive` to parse and validate the new block with safe defaults and warnings for invalid values.
- Implemented `GlobalReviveUnDeathBan` runnable that computes the next execution time in the configured timezone, undeathbans all ongoing bans and resets online players' revive cooldowns when triggered.
- Wired the runnable into plugin lifecycle (`AugmentedHardcore` starts/stops it), changed `PlayerData` to expose `getTimeTillNextRevive()` (returns global countdown when enabled), skip per-player revive playtime runnables in global mode, and added `resetReviveCooldown()`; updated placeholders and `/nextrevive` to use the unified `getTimeTillNextRevive()` return value.

### Testing
- Ran `mvn -q test` in the project; the build/tests failed at compile due to an existing unrelated symbol error in the repository: `PlayerData.java:[270,105] cannot find symbol getEnableLosingLivesInWorlds()` on `ConfigurationLivesAndLifeParts`, so automated tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb898a38b8832998ea95493d8c88d1)