### PR TITLE
Add option to control DeathBan with GlobalReviveUnDeathBan schedule

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationDeathBan.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 
 public class ConfigurationDeathBan {
     private final boolean useDeathBan;
+    private final boolean controlUseDeathBanWithGlobalReviveUnDeathBan;
     private final EnumMap<DamageCause, BanConfiguration> banTimes;
     private final BanList.Type banType;
     private final BanTimeType banTimeType;
@@ -29,8 +30,9 @@ public class ConfigurationDeathBan {
     private final List<String> commandsOnDeathBan;
     private final List<String> disableBanInWorlds;
 
-    public ConfigurationDeathBan(boolean useDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType, BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan, boolean lightningOnDeathBan, String spectatorBanRespawnWorld, List<String> commandsOnDeathBan, List<String> disableBanInWorlds) {
+    public ConfigurationDeathBan(boolean useDeathBan, boolean controlUseDeathBanWithGlobalReviveUnDeathBan, EnumMap<DamageCause, BanConfiguration> banTimes, BanList.Type banType, BanTimeType banTimeType, GrowthType banTimeByPlaytimeGrowthType, boolean selfHarmBan, boolean lightningOnDeathBan, String spectatorBanRespawnWorld, List<String> commandsOnDeathBan, List<String> disableBanInWorlds) {
         this.useDeathBan = useDeathBan;
+        this.controlUseDeathBanWithGlobalReviveUnDeathBan = controlUseDeathBanWithGlobalReviveUnDeathBan;
         this.banTimes = banTimes;
         this.banType = banType;
         this.banTimeType = banTimeType;
@@ -47,6 +49,7 @@ public class ConfigurationDeathBan {
 
         //configurations
         boolean cUseDeathBan = section.getBoolean("UseDeathBan", true);
+        boolean cControlUseDeathBanWithGlobalReviveUnDeathBan = section.getBoolean("ControlUseDeathBanWithGlobalReviveUnDeathBan", false);
         EnumMap<DamageCause, BanConfiguration> cBanTimes = new EnumMap<>(DamageCause.class);
         BanList.Type cBanType = ConfigUtils.getBanType("BanType", section.getString("BanType", BanList.Type.NAME.name()), BanList.Type.NAME);
         BanTimeType cBanTimeType = ConfigUtils.getBanTimeType("BanTimeType", section.getString("BanTimeType", BanTimeType.STATIC.name()), BanTimeType.STATIC);
@@ -74,6 +77,7 @@ public class ConfigurationDeathBan {
 
         return new ConfigurationDeathBan(
                 cUseDeathBan,
+                cControlUseDeathBanWithGlobalReviveUnDeathBan,
                 cBanTimes,
                 cBanType,
                 cBanTimeType,
@@ -111,7 +115,19 @@ public class ConfigurationDeathBan {
     }
 
     public boolean isUseDeathBan() {
-        return useDeathBan;
+        if (!this.useDeathBan) {
+            return false;
+        }
+
+        if (!this.controlUseDeathBanWithGlobalReviveUnDeathBan) {
+            return true;
+        }
+
+        return JavaPlugin.getPlugin(AugmentedHardcore.class).getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration().isEnabled();
+    }
+
+    public boolean isControlUseDeathBanWithGlobalReviveUnDeathBan() {
+        return controlUseDeathBanWithGlobalReviveUnDeathBan;
     }
 
     public boolean isLightningOnDeathBan() {

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -130,6 +130,10 @@ DisableLosingLifePartsInWorlds: [ ]
 #Should the plugin use the death ban system configured below?
 UseDeathBan: true
 
+#If true, UseDeathBan will only stay active while Reviving.GlobalReviveUnDeathBan.Enabled is true.
+#This lets the global schedule control whether death bans are active.
+ControlUseDeathBanWithGlobalReviveUnDeathBan: false
+
 #What ban times should these death causes have when a player reaches 0 lives?
 #Bantime:         The ban time in minutes this damage cause will give the player.
 #                 Minimum is 0, -1 will ban permanently


### PR DESCRIPTION
### Motivation

- Allow the server to let a single global revive/un-death-ban schedule enable or disable the death ban system so admins can centrally control whether death bans are active.

### Description

- Add a new boolean field `controlUseDeathBanWithGlobalReviveUnDeathBan` with a getter and include it in the constructor and deserialization process in `ConfigurationDeathBan`.
- Update `ConfigurationDeathBan.deserialize` to read `ControlUseDeathBanWithGlobalReviveUnDeathBan` from the config and populate the new field.
- Change `isUseDeathBan` to return `false` if `useDeathBan` is `false`, return `true` if the control flag is `false`, and otherwise consult `getConfigurations().getReviveConfiguration().getGlobalReviveUnDeathBanConfiguration().isEnabled()` to determine runtime state.
- Add `ControlUseDeathBanWithGlobalReviveUnDeathBan: false` and explanatory comments to `config.yml` so the behavior is configurable by server operators.

### Testing

- Performed a local project build to verify the code compiles successfully after the changes.
- No automated unit tests were added or modified in this change and the existing test suite was left unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb956ef6388329bf520c499c068153)