### PR TITLE
Add GLOBALREVIVE BanTimeType option to use global revive schedule for bantime

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/enums/BanTimeType.java
@@ -13,7 +13,8 @@ public enum BanTimeType {
     STATIC,
     BANCOUNT,
     PLAYTIME,
-    TIMESINCELASTDEATH;
+    TIMESINCELASTDEATH,
+    GLOBALREVIVE;
 
     public int getBantime(Player player, PlayerData playerData, int max) {
         GrowthType growthType = JavaPlugin.getPlugin(AugmentedHardcore.class).getConfigurations().getDeathBanConfiguration().getBanTimeByPlaytimeGrowthType();
@@ -26,6 +27,8 @@ public enum BanTimeType {
                 return growthType.getBanTime(player.getStatistic(Statistic.PLAY_ONE_MINUTE) / 1200, max);
             case TIMESINCELASTDEATH:
                 return growthType.getBanTime((int) MessageUtils.timeBetweenDatesToTicks(LocalDateTime.now(), playerData.getLastDeath()) / 1200, max);
+            case GLOBALREVIVE:
+                return (int) Math.max(playerData.getTimeTillNextRevive() / 1200, 0);
             default:
                 return 0;
         }

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -409,7 +409,9 @@ BanType: name
 #Timesincelastdeath: Time since last death will be used for determining the bantime.
 #                    Bantimes will increase the longer the player stays alive.
 #                    Every death will reset the bantime back to 0, above times will be used as maximum ban time.
-# -> static/bancount/playtime/timesincelastdeath
+#Globalrevive:       Time until the next GlobalReviveUnDeathBan run will be used for determining the bantime.
+#                    This effectively bans players until the next global revive/un-deathban executes.
+# -> static/bancount/playtime/timesincelastdeath/globalrevive
 BanTimeType: static
 
 #At what rate should the ban time by playtime grow?


### PR DESCRIPTION
### Motivation
- Provide a way to calculate death-ban duration based on the time until the next global revive/un-deathban run so players can be banned until the next global reset cycle.

### Description
- Added a new enum value `GLOBALREVIVE` to `BanTimeType`.
- Implemented the `GLOBALREVIVE` branch to return bantime based on `playerData.getTimeTillNextRevive()` converted to minutes.
- Updated `src/resources/config.yml` documentation to include the `globalrevive` option in the `BanTimeType` choices.

### Testing
- Ran unit tests with `mvn test -q`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9dff5674832982755031434eb91a)