### PR TITLE
Handle YAML-coerced TimeOfDay values for global revive scheduling

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/configurationDomain/ConfigurationRevive.java
@@ -74,13 +74,7 @@ public class ConfigurationRevive {
 
         int intervalHours = Math.max(1, section.getInt("IntervalHours", 24));
 
-        LocalTime timeOfDay;
-        try {
-            timeOfDay = LocalTime.parse(section.getString("TimeOfDay", "00:00"));
-        } catch (Exception ex) {
-            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.TimeOfDay value. Expected HH:mm, defaulting to 00:00.");
-            timeOfDay = LocalTime.MIDNIGHT;
-        }
+        LocalTime timeOfDay = parseTimeOfDay(section);
 
         DayOfWeek dayOfWeek;
         try {
@@ -101,6 +95,40 @@ public class ConfigurationRevive {
         }
 
         return new GlobalReviveUnDeathBanConfiguration(enabled, scheduleType, intervalHours, timeOfDay, dayOfWeek, dayOfMonth, timezone);
+    }
+
+    private static LocalTime parseTimeOfDay(ConfigurationSection section) {
+        Object rawTimeOfDay = section.get("TimeOfDay");
+
+        if (rawTimeOfDay instanceof Number number) {
+            int minutesSinceMidnight = number.intValue();
+            if (minutesSinceMidnight >= 0 && minutesSinceMidnight < 24 * 60) {
+                JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "GlobalReviveUnDeathBan.TimeOfDay was loaded as a number ({0}). This can happen when HH:mm is unquoted in YAML. Interpreting it as minutes since midnight.", minutesSinceMidnight);
+                return LocalTime.of(minutesSinceMidnight / 60, minutesSinceMidnight % 60);
+            }
+
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.TimeOfDay numeric value ({0}). Expected HH:mm, defaulting to 00:00.", minutesSinceMidnight);
+            return LocalTime.MIDNIGHT;
+        }
+
+        String rawTimeOfDayString = section.getString("TimeOfDay", "00:00");
+
+        try {
+            return LocalTime.parse(rawTimeOfDayString);
+        } catch (Exception ignored) {
+            try {
+                int minutesSinceMidnight = Integer.parseInt(rawTimeOfDayString);
+                if (minutesSinceMidnight >= 0 && minutesSinceMidnight < 24 * 60) {
+                    JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "GlobalReviveUnDeathBan.TimeOfDay looked numeric ({0}). Interpreting it as minutes since midnight.", minutesSinceMidnight);
+                    return LocalTime.of(minutesSinceMidnight / 60, minutesSinceMidnight % 60);
+                }
+            } catch (NumberFormatException ignoredAgain) {
+                // ignored intentionally, falls through to default warning below
+            }
+
+            JavaPlugin.getPlugin(AugmentedHardcore.class).getLogger().log(Level.WARNING, "Invalid GlobalReviveUnDeathBan.TimeOfDay value. Expected HH:mm, defaulting to 00:00.");
+            return LocalTime.MIDNIGHT;
+        }
     }
 
     public boolean isUseRevive() {

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -572,7 +572,7 @@ GlobalReviveUnDeathBan:
   #Only used by INTERVAL_HOURS.
   IntervalHours: 24
 
-  #Used by DAILY / WEEKLY / MONTHLY. 24h format (HH:mm).
+  #Used by DAILY / WEEKLY / MONTHLY. 24h format (HH:mm). Keep this quoted (e.g. "11:53").
   TimeOfDay: "00:00"
 
   #Only used by WEEKLY.


### PR DESCRIPTION
### Motivation
- YAML 1.1 parsers can coerce unquoted `HH:mm` values into sexagesimal numbers (e.g. `11:53` -> `713`), causing the previous `LocalTime.parse` to fail and the global revive schedule to default to midnight.
- The change makes the configuration parsing resilient to either string or numeric representations so global revive timing isn't silently broken.

### Description
- Added a helper `parseTimeOfDay(ConfigurationSection)` that accepts numeric `TimeOfDay` values (interpreted as minutes-since-midnight) and string `HH:mm` values, returning a `LocalTime` and logging clear warnings for fallbacks or invalid inputs.
- Replaced the previous direct `LocalTime.parse(section.getString("TimeOfDay", "00:00"))` call with `parseTimeOfDay(section)` in `ConfigurationRevive`.
- Updated `src/resources/config.yml` comment to explicitly instruct users to keep `TimeOfDay` quoted (example: `"11:53"`).

### Testing
- Ran `mvn -q test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba02986b88329b63c9c9ceeb54f3f)