### PR TITLE
Harden global revive scheduler execution

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
@@ -15,6 +15,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
+import java.util.logging.Level;
 
 public class GlobalReviveUnDeathBan extends BukkitRunnable {
     private final AugmentedHardcore plugin;
@@ -32,7 +33,8 @@ public class GlobalReviveUnDeathBan extends BukkitRunnable {
         if (!this.configuration.isEnabled()) {
             return;
         }
-        this.task = this.runTaskTimerAsynchronously(this.plugin, 1200L, 1200L);
+        this.plugin.getLogger().log(Level.INFO, "GlobalReviveUnDeathBan enabled. Next run scheduled for {0}.", this.nextRunAt);
+        this.task = this.runTaskTimer(this.plugin, 1200L, 1200L);
     }
 
     public void stop() {
@@ -56,13 +58,19 @@ public class GlobalReviveUnDeathBan extends BukkitRunnable {
             return;
         }
 
-        ZonedDateTime now = ZonedDateTime.now(this.configuration.getTimezone());
-        if (now.isBefore(this.nextRunAt)) {
-            return;
-        }
+        try {
+            ZonedDateTime now = ZonedDateTime.now(this.configuration.getTimezone());
+            if (now.isBefore(this.nextRunAt)) {
+                return;
+            }
 
-        this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(this::runGlobalReset, this.plugin.getExecutor());
-        this.nextRunAt = computeNextRun(now.plusSeconds(1));
+            this.plugin.getLogger().log(Level.INFO, "Running GlobalReviveUnDeathBan at {0}.", now);
+            this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(this::runGlobalReset, this.plugin.getExecutor());
+            this.nextRunAt = computeNextRun(now.plusSeconds(1));
+            this.plugin.getLogger().log(Level.INFO, "GlobalReviveUnDeathBan completed. Next run scheduled for {0}.", this.nextRunAt);
+        } catch (Exception ex) {
+            this.plugin.getLogger().log(Level.SEVERE, "GlobalReviveUnDeathBan failed to execute.", ex);
+        }
     }
 
     private void runGlobalReset(ServerData serverData) {


### PR DESCRIPTION
### Motivation

- The global scheduled "GlobalReviveUnDeathBan" job could silently miss its configured `TimeOfDay` run or stop due to uncaught exceptions and async scheduling fragility, making global revives/un-deathbans unreliable.

### Description

- Run the scheduler polling task on the main server thread by switching from `runTaskTimerAsynchronously` to `runTaskTimer` to avoid async timing fragility.
- Add informational logs at startup, on execution start, and after completion to make scheduled runs and the next run timestamp observable through the plugin logger.
- Wrap the scheduler `run()` body in a `try/catch` and log `SEVERE` on unexpected exceptions to prevent silent task death and aid debugging.
- Changes made in `src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java`.

### Testing

- Ran the project compile step with `mvn -q -DskipTests compile` which completed successfully. 
- Executed unit tests with `mvn -q test` during validation and no test failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba54342ac83298638ed56738c6a8c)