### PR TITLE
Fix global revive scheduler execution and reload handling

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
+++ b/src/com/backtobedrock/augmentedhardcore/AugmentedHardcore.java
@@ -83,8 +83,6 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         //update checker
         this.updateChecker = new UpdateChecker();
         this.updateChecker.start();
-        this.globalReviveUnDeathBan = new GlobalReviveUnDeathBan();
-        this.globalReviveUnDeathBan.start();
 
         //bstats metrics
         Metrics metrics = new Metrics(this, 10843);
@@ -150,6 +148,12 @@ public class AugmentedHardcore extends JavaPlugin implements Listener {
         this.setupDatabase();
         this.initRepositories();
         this.registerListeners();
+
+        if (this.globalReviveUnDeathBan != null) {
+            this.globalReviveUnDeathBan.stop();
+        }
+        this.globalReviveUnDeathBan = new GlobalReviveUnDeathBan();
+        this.globalReviveUnDeathBan.start();
     }
 
     private void prepareConfigFiles() {

--- a/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
+++ b/src/com/backtobedrock/augmentedhardcore/runnables/GlobalReviveUnDeathBan.java
@@ -58,19 +58,27 @@ public class GlobalReviveUnDeathBan extends BukkitRunnable {
             return;
         }
 
-        try {
-            ZonedDateTime now = ZonedDateTime.now(this.configuration.getTimezone());
-            if (now.isBefore(this.nextRunAt)) {
-                return;
-            }
-
-            this.plugin.getLogger().log(Level.INFO, "Running GlobalReviveUnDeathBan at {0}.", now);
-            this.plugin.getServerRepository().getServerData(this.plugin.getServer()).thenAcceptAsync(this::runGlobalReset, this.plugin.getExecutor());
-            this.nextRunAt = computeNextRun(now.plusSeconds(1));
-            this.plugin.getLogger().log(Level.INFO, "GlobalReviveUnDeathBan completed. Next run scheduled for {0}.", this.nextRunAt);
-        } catch (Exception ex) {
-            this.plugin.getLogger().log(Level.SEVERE, "GlobalReviveUnDeathBan failed to execute.", ex);
+        ZonedDateTime now = ZonedDateTime.now(this.configuration.getTimezone());
+        if (now.isBefore(this.nextRunAt)) {
+            return;
         }
+
+        this.plugin.getLogger().log(Level.INFO, "Running GlobalReviveUnDeathBan at {0}.", now);
+        this.nextRunAt = computeNextRun(now.plusSeconds(1));
+
+        this.plugin.getServerRepository().getServerData(this.plugin.getServer())
+                .thenAccept(serverData -> Bukkit.getScheduler().runTask(this.plugin, () -> {
+                    try {
+                        this.runGlobalReset(serverData);
+                        this.plugin.getLogger().log(Level.INFO, "GlobalReviveUnDeathBan completed. Next run scheduled for {0}.", this.nextRunAt);
+                    } catch (Exception ex) {
+                        this.plugin.getLogger().log(Level.SEVERE, "GlobalReviveUnDeathBan failed to execute on main thread.", ex);
+                    }
+                }))
+                .exceptionally(ex -> {
+                    this.plugin.getLogger().log(Level.SEVERE, "GlobalReviveUnDeathBan failed to load server data.", ex);
+                    return null;
+                });
     }
 
     private void runGlobalReset(ServerData serverData) {


### PR DESCRIPTION
### Motivation
- The global revive task previously ran its reset logic from an async callback which can access Bukkit state off the main thread and silently fail, preventing players from being unbanned/revived at the scheduled time.  
- Reloading the plugin via `initialize()` did not recreate the `GlobalReviveUnDeathBan` runnable, so schedule/config changes from `/ah reload` were not applied.  
- Centralize lifecycle handling so the global revive scheduler is started/stopped deterministically and honors config changes.

### Description
- Changed `GlobalReviveUnDeathBan.run()` to compute the next run, load `ServerData` asynchronously, and then dispatch `runGlobalReset` back onto the Bukkit main thread with `Bukkit.getScheduler().runTask(...)`.  
- Added explicit error handling/logging for async server-data load failures and exceptions thrown while executing reset logic on the main thread.  
- Moved creation/start of `GlobalReviveUnDeathBan` into `initialize()` and removed the duplicate startup from `onEnable()`, and now `initialize()` stops any existing instance before recreating it so `/ah reload` updates the schedule.  
- Adjusted logging so completion is logged after the actual reset work runs on the main thread.

### Testing
- Built the project successfully: `mvn -q -DskipTests package` (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba822d6588329ab5a45f5ba2f3408)