### PR TITLE
Add 'nullified' flag to Ban, persist it to DB, and always record zero-length deaths

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/Ban.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/Ban.java
@@ -31,8 +31,13 @@ public class Ban {
     private final long timeSincePreviousDeathBan;
     private final long timeSincePreviousDeath;
     private LocalDateTime expirationDate;
+    private boolean nullified;
 
     public Ban(LocalDateTime startDate, LocalDateTime expirationDate, int banTime, DamageCause damageCause, DamageCauseType damageCauseType, Location location, Killer killer, Killer inCombatWith, String deathMessage, long timeSincePreviousDeathBan, long timeSincePreviousDeath) {
+        this(startDate, expirationDate, banTime, damageCause, damageCauseType, location, killer, inCombatWith, deathMessage, timeSincePreviousDeathBan, timeSincePreviousDeath, false);
+    }
+
+    public Ban(LocalDateTime startDate, LocalDateTime expirationDate, int banTime, DamageCause damageCause, DamageCauseType damageCauseType, Location location, Killer killer, Killer inCombatWith, String deathMessage, long timeSincePreviousDeathBan, long timeSincePreviousDeath, boolean nullified) {
         this.plugin = JavaPlugin.getPlugin(AugmentedHardcore.class);
         this.startDate = startDate;
         this.expirationDate = expirationDate;
@@ -45,6 +50,7 @@ public class Ban {
         this.deathMessage = deathMessage;
         this.timeSincePreviousDeathBan = timeSincePreviousDeathBan;
         this.timeSincePreviousDeath = timeSincePreviousDeath;
+        this.nullified = nullified;
     }
 
     public static Ban Deserialize(ConfigurationSection section) {
@@ -59,6 +65,7 @@ public class Ban {
         int cBanTime = section.getInt("BanTime", 0);
         long cTimeSincePreviousDeathBan = section.getLong("TimeSincePreviousDeathBan", 0);
         long cTimeSincePreviousDeath = section.getLong("TimeSincePreviousDeath", 0);
+        boolean cNullified = section.getBoolean("Nullified", false);
 
         ConfigurationSection locationSection = section.getConfigurationSection("Location");
         if (locationSection != null) {
@@ -76,7 +83,7 @@ public class Ban {
             cInCombatWith = Killer.Deserialize(inCombatWithSection);
         }
 
-        return new Ban(cStartDate, cExpirationDate, cBanTime, cDamageCause, cDamageCauseType, cLocation, cKiller, cInCombatWith, cDeathMessage, cTimeSincePreviousDeathBan, cTimeSincePreviousDeath);
+        return new Ban(cStartDate, cExpirationDate, cBanTime, cDamageCause, cDamageCauseType, cLocation, cKiller, cInCombatWith, cDeathMessage, cTimeSincePreviousDeathBan, cTimeSincePreviousDeath, cNullified);
     }
 
     public String getBanMessage() {
@@ -120,6 +127,14 @@ public class Ban {
         return banTime;
     }
 
+    public boolean isNullified() {
+        return nullified;
+    }
+
+    public void setNullified(boolean nullified) {
+        this.nullified = nullified;
+    }
+
     public Map<String, Object> serialize() {
         Map<String, Object> map = new HashMap<>();
         Map<String, Object> locationMap = new HashMap<>();
@@ -140,6 +155,7 @@ public class Ban {
         map.put("BanTime", this.banTime);
         map.put("TimeSincePreviousDeathBan", this.timeSincePreviousDeathBan);
         map.put("TimeSincePreviousDeath", this.timeSincePreviousDeath);
+        map.put("Nullified", this.nullified);
 
         return map;
     }

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -332,8 +332,11 @@ public class PlayerData {
             return;
         }
 
-        //ban player
+        //always store a death record, even when it does not trigger an active death ban
         if (ban.getBanTime() == 0) {
+            ban.setNullified(true);
+            this.addBan(ban);
+            this.plugin.getPlayerRepository().updatePlayerData(this);
             return;
         }
 

--- a/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/ServerData.java
@@ -143,6 +143,7 @@ public class ServerData {
         Unban unban = this.ongoingBans.remove(player.getUniqueId());
         if (unban != null) {
             unban.getBan().ban().setExpirationDate(LocalDateTime.now());
+            unban.getBan().ban().setNullified(true);
             this.plugin.getPlayerRepository().getByPlayer(player).thenAcceptAsync(playerData -> {
                 this.ongoingIPBans.remove(playerData.getLastKnownIp());
                 if (player.getPlayer() != null) {

--- a/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
+++ b/src/com/backtobedrock/augmentedhardcore/mappers/ban/MySQLBanMapper.java
@@ -24,6 +24,12 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
     public BanEntry getBanFromResultSetSync(ResultSet resultSet) {
         try {
             if (resultSet.getObject("ban_id") != null) {
+                boolean nullified;
+                try {
+                    nullified = resultSet.getBoolean("nullified");
+                } catch (SQLException ignored) {
+                    nullified = false;
+                }
                 return new BanEntry(resultSet.getInt("ban_id"),
                         new Ban(
                                 resultSet.getTimestamp("start_date").toLocalDateTime(),
@@ -36,7 +42,8 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                                 resultSet.getBoolean("in_combat") ? new Killer(resultSet.getString("in_combat_with_name"), resultSet.getString("in_combat_with_display_name"), ConfigUtils.getEntityType(resultSet.getString("in_combat_with_entity_type"))) : null,
                                 resultSet.getString("death_message"),
                                 resultSet.getLong("time_since_previous_death_ban"),
-                                resultSet.getLong("time_since_previous_death")
+                                resultSet.getLong("time_since_previous_death"),
+                                nullified
                         )
                 );
             }
@@ -69,8 +76,8 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
     }
 
     public void updateBanSync(Server server, UUID uuid, BanEntry ban) {
-        String sql = "INSERT INTO ah_ban (`ban_id`,`player_uuid`,`server_ip`,`server_port`,`start_date`,`expiration_date`,`ban_time`,`damage_cause`,`damage_cause_type`,`world`,`x`,`y`,`z`,`has_killer`,`killer_name`,`killer_display_name`,`killer_entity_type`,`in_combat`,`in_combat_with_name`,`in_combat_with_display_name`,`in_combat_with_entity_type`,`death_message`,`time_since_previous_death_ban`,`time_since_previous_death`)"
-                + "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+        String sql = "INSERT INTO ah_ban (`ban_id`,`player_uuid`,`server_ip`,`server_port`,`start_date`,`expiration_date`,`ban_time`,`damage_cause`,`damage_cause_type`,`world`,`x`,`y`,`z`,`has_killer`,`killer_name`,`killer_display_name`,`killer_entity_type`,`in_combat`,`in_combat_with_name`,`in_combat_with_display_name`,`in_combat_with_entity_type`,`death_message`,`time_since_previous_death_ban`,`time_since_previous_death`,`nullified`)"
+                + "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
                 + "ON DUPLICATE KEY UPDATE "
                 + "`server_ip` = ?,"
                 + "`server_port` = ?,"
@@ -93,11 +100,12 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
                 + "`in_combat_with_entity_type`= ?,"
                 + "`death_message` = ?,"
                 + "`time_since_previous_death_ban` = ?,"
-                + "`time_since_previous_death` = ?;";
+                + "`time_since_previous_death` = ?,"
+                + "`nullified` = ?;";
 
         try (Connection connection = this.database.getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
             bindBanParameters(preparedStatement, 1, server, uuid, ban);
-            bindBanParameters(preparedStatement, 25, server, uuid, ban);
+            bindBanParameters(preparedStatement, 26, server, uuid, ban);
             preparedStatement.execute();
         } catch (SQLException | UnknownHostException e) {
             this.plugin.getLogger().log(Level.SEVERE, "Could not update ban.", e);
@@ -131,7 +139,8 @@ public class MySQLBanMapper extends AbstractMapper implements IBanMapper {
         preparedStatement.setString(index++, ban.ban().getInCombatWith() == null ? null : ban.ban().getInCombatWith().getType().name());
         preparedStatement.setString(index++, ban.ban().getDeathMessage());
         preparedStatement.setLong(index++, ban.ban().getTimeSincePreviousDeathBan());
-        preparedStatement.setLong(index, ban.ban().getTimeSincePreviousDeath());
+        preparedStatement.setLong(index++, ban.ban().getTimeSincePreviousDeath());
+        preparedStatement.setBoolean(index, ban.ban().isNullified());
     }
 
     @Override

--- a/src/resources/dbsetup.sql
+++ b/src/resources/dbsetup.sql
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS ah_ban
     death_message TINYTEXT NOT NULL,
     time_since_previous_death_ban BIGINT UNSIGNED NOT NULL,
     time_since_previous_death BIGINT UNSIGNED NOT NULL,
+    nullified TINYINT NOT NULL DEFAULT 0,
     PRIMARY KEY (ban_id,player_uuid),
     CONSTRAINT player_uuid FOREIGN KEY (player_uuid) REFERENCES ah_player (player_uuid) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT fk_server FOREIGN KEY (server_ip, server_port) REFERENCES ah_server (server_ip, server_port) ON DELETE SET NULL ON UPDATE SET NULL


### PR DESCRIPTION
### Motivation

- Allow recording death events that do not produce an active ban by marking them as `nullified` so historical records are preserved.
- Persist the `nullified` state through serialization and the MySQL mapper so ban state remains consistent across restarts and replication.
- Ensure server-side removal of ongoing bans marks them as `nullified` to retain the record while effectively ending the ban.

### Description

- Added a `nullified` boolean field to `Ban` with constructors, `isNullified`/`setNullified`, and included it in `serialize`/`Deserialize` logic so the flag is stored in config data.
- Updated `PlayerData` death handling to always add a `Ban` record even when `banTime == 0`, marking such records as `nullified` and immediately persisting the updated `PlayerData` via `updatePlayerData`.
- Updated `ServerData.removeBan` to set `nullified` on ban objects when removing an ongoing ban and to continue removing IP/state as before.
- Extended `MySQLBanMapper` to read the `nullified` column safely (fallback to `false` if missing), to include `nullified` in `INSERT ... ON DUPLICATE KEY UPDATE` SQL and bind the parameter when writing to the database.
- Updated `dbsetup.sql` to add the `nullified` column (`TINYINT NOT NULL DEFAULT 0`) to the `ah_ban` table schema.

### Testing

- Ran the project unit test suite with `mvn test` and observed the tests completed successfully.
- Verified MySQL mapper can read rows that both include and omit the `nullified` column (the code falls back to `false` when the column is absent) via the updated `getBanFromResultSetSync` logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb871e0f08329998339407a79079d)