### PR TITLE
Null-safe combat tag cleanup to prevent NPE on player death

### DIFF
--- a/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
+++ b/src/com/backtobedrock/augmentedhardcore/domain/data/PlayerData.java
@@ -516,8 +516,19 @@ public class PlayerData {
     }
 
     public void unCombatTag() {
-        if (!this.combatTag.isEmpty()) {
-            new ArrayList<>(this.combatTag).forEach(AbstractCombatTag::stop);
+        if (this.combatTag == null || this.combatTag.isEmpty()) {
+            return;
+        }
+
+        Iterator<AbstractCombatTag> iterator = this.combatTag.iterator();
+        while (iterator.hasNext()) {
+            AbstractCombatTag tag = iterator.next();
+            if (tag == null) {
+                iterator.remove();
+                continue;
+            }
+
+            tag.stop();
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a `NullPointerException` triggered during player death cleanup when `combatTag` is null or contains null entries by hardening the combat-tag clearing logic.

### Description
- Update `PlayerData.unCombatTag()` to return early if `combatTag` is null or empty, remove null `AbstractCombatTag` entries while iterating, and only call `stop()` on non-null tags so existing tags are still stopped as before.

### Testing
- Ran unit tests with `mvn -q test`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f919f9b08329ae4eb65c9f4d4d16)